### PR TITLE
#223 deploy-to-productionワークフローの修正

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -70,8 +70,9 @@ jobs:
 
       - name: Create distribution zip
         run: |
-          mkdir hametuha
-          rsync -av --exclude=hametuha --exclude-from=.distignore ./ ./hametuha/
+          mkdir hametuha-tmp
+          rsync -av --exclude=hametuha-tmp --exclude-from=.distignore ./ ./hametuha-tmp/
+          mv hametuha-tmp hametuha
           zip -r hametuha.zip hametuha/
         working-directory: themes/hametuha
 

--- a/themes/hametuha/.distignore
+++ b/themes/hametuha/.distignore
@@ -15,7 +15,7 @@ phpcs.ruleset.xml
 phpunit.xml.dist
 README.md
 webpack.config.js
-bin
+/bin
 tmp
 tests
 style.css.bak


### PR DESCRIPTION
- build.shの実行権限問題を修正（bashコマンドを明示的に指定）
- distribution zip作成時のvendor/hametuha除外問題を修正
- .distignoreのbinパス指定を修正（/binでルートのみ除外）
- environment保護ルールを再有効化

Fixes #223