### PR TITLE
下書き状態のseriesでプレビューできない問題を修正

### DIFF
--- a/themes/hametuha/hooks/series.php
+++ b/themes/hametuha/hooks/series.php
@@ -189,6 +189,10 @@ add_filter( 'posts_join', function ( $join, WP_Query $wp_query ) {
 	if ( 'series' !== $wp_query->get( 'post_type' ) ) {
 		return $join;
 	}
+	// シングルページ（プレビュー含む）では子投稿チェックをスキップ
+	if ( $wp_query->is_singular() ) {
+		return $join;
+	}
 
 	global $wpdb;
 	// 少なくとも1つは公開済みの子投稿が紐づいている連載のみを表示


### PR DESCRIPTION
## Summary
- 下書き状態のseriesで「プレビュー」が404になる問題を修正
- `hooks/series.php` の `posts_join` フィルターが、アーカイブだけでなくシングルページ（プレビュー含む）にも適用されていたことが原因
- `$wp_query->is_singular()` チェックを追加し、シングルページではINNER JOINをスキップするようにした

## 原因
`posts_join` フィルターで「公開済みの子投稿が1つ以上あるseriesのみ」に絞り込むINNER JOINが、プレビュー時のメインクエリにも適用されていた。子投稿が0件のseriesはクエリ結果から除外され、404になっていた。

## Test plan
- [ ] 子投稿が紐づいていない下書き状態のseriesでプレビューが表示されることを確認
- [ ] 子投稿が紐づいている公開済みseriesのシングルページが正常に表示されることを確認
- [ ] seriesアーカイブ（一覧ページ）で、子投稿のないseriesが引き続き非表示であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)