### PR TITLE
イベント参加機能の不具合修正と表示改善

### DIFF
--- a/themes/hametuha/src/Hametuha/Hooks/AnnouncementHooks.php
+++ b/themes/hametuha/src/Hametuha/Hooks/AnnouncementHooks.php
@@ -65,6 +65,12 @@ class AnnouncementHooks extends Singleton {
 			case 'participation':
 				if ( $event->can_participate() ) {
 					echo esc_html( $event->get_participating_period() );
+					$count = $event->participating_count();
+					$limit = $event->participating_limit( false );
+					$label = $limit > 0
+						? sprintf( '%d / %s', $count, number_format_i18n( $limit ) . '名' )
+						: sprintf( '%d名 / 無制限', $count );
+					echo '<br><strong>' . esc_html( $label ) . '</strong>';
 				} else {
 					echo '---';
 				}

--- a/themes/hametuha/src/Hametuha/MetaBoxes/AnnouncementMetaBox.php
+++ b/themes/hametuha/src/Hametuha/MetaBoxes/AnnouncementMetaBox.php
@@ -61,8 +61,40 @@ class AnnouncementMetaBox extends EditMetaBox {
 	 * 詳細説明文
 	 */
 	protected function desc() {
-		echo <<<HTML
-        <p class="description">参加する何かの場合は入力してください<p>
-HTML;
+		return sprintf( '<p>%s</p>', esc_html__( '参加表明をするイベントの場合は条件を入力してください。', 'hametuha' ) );
+	}
+
+	/**
+	 * メタボックスの内容を描画
+	 *
+	 * @param \WP_Post $post
+	 */
+	public function render( \WP_Post $post ) {
+		parent::render( $post );
+		$event = new Announcement( $post );
+		if ( ! $event->can_participate() ) {
+			return;
+		}
+		$participants = $event->get_participants();
+		printf( '<h4 style="margin-top:1em;">参加者一覧（%d名）</h4>', count( $participants ) );
+		if ( empty( $participants ) ) {
+			echo '<p>まだ参加者はいません。</p>';
+			return;
+		}
+		echo '<ul class="hametuha-participants-list" style="display:flex;flex-wrap:wrap;gap:6px;padding:0;margin:0;list-style:none;">';
+		foreach ( $participants as $p ) {
+			$user = get_userdata( $p['id'] );
+			if ( ! $user ) {
+				continue;
+			}
+			$url = home_url( '/doujin/detail/' . $user->user_nicename . '/' );
+			printf(
+				'<li style="margin:0;"><a href="%s" target="_blank" rel="noopener noreferrer" style="display:inline-flex;align-items:center;gap:4px;padding:4px 8px;background:#f6f7f7;border:1px solid #ddd;border-radius:4px;text-decoration:none;">%s<span>%s</span></a></li>',
+				esc_url( $url ),
+				get_avatar( $user->ID, 24 ),
+				esc_html( $user->display_name )
+			);
+		}
+		echo '</ul>';
 	}
 }

--- a/themes/hametuha/src/Hametuha/WpApi/EventParticipants.php
+++ b/themes/hametuha/src/Hametuha/WpApi/EventParticipants.php
@@ -106,11 +106,11 @@ class EventParticipants extends WpApi {
 			$organizer = get_userdata( $post->post_author );
 			do_action( 'hametuha_notification', 'participant', "参加状況: {$post->post_title}", $organizer->user_email, [
 				'post'        => $post,
-				'status'      => $request['status'],
+				'status'      => true,
 				'organizer'   => $organizer,
 				'participant' => get_userdata( get_current_user_id() ),
 				'update'      => $updated,
-				'message'     => $request['text'],
+				'message'     => $request->get_param( 'text' ),
 			] );
 		}
 		return new \WP_REST_Response( $event->get_user_object( $ticket_id ) );
@@ -175,6 +175,18 @@ class EventParticipants extends WpApi {
 			wp_update_comment( [
 				'comment_ID'      => $ticket_id,
 				'comment_content' => implode( "\n\n---\n\n", array_filter( $all_comment ) ),
+			] );
+		}
+		if ( get_current_user_id() != $post->post_author ) {
+			// 主催者に不参加を連絡
+			$organizer = get_userdata( $post->post_author );
+			do_action( 'hametuha_notification', 'participant', "参加状況: {$post->post_title}", $organizer->user_email, [
+				'post'        => $post,
+				'status'      => false,
+				'organizer'   => $organizer,
+				'participant' => get_userdata( get_current_user_id() ),
+				'update'      => true,
+				'message'     => $comment,
 			] );
 		}
 		return new \WP_REST_Response( [

--- a/themes/hametuha/templates/mail/participant.php
+++ b/themes/hametuha/templates/mail/participant.php
@@ -8,10 +8,10 @@
  * @var bool $update
  * @var string $message
  */
-$participant = $args['participants'] ?? null;
+$participant = $args['participant'] ?? null;
 $update      = $args['update'] ?? false;
 $status      = $args['status'] ?? false;
-$message     = $args['message'] ?? ''
+$message     = $args['message'] ?? '';
 
 ?>
 <?php echo esc_html( $participant->display_name ); ?> さんの参加状況です。
@@ -21,7 +21,7 @@ $message     = $args['message'] ?? ''
 printf(
 	'%s: %s',
 	$update ? '更新' : '新規',
-	$status ? '<strong>参加</strong>' : '<em>不参加</em>'
+	$status ? '参加' : '不参加'
 );
 ?>
 


### PR DESCRIPTION
## Summary
- Angular→React 移行時に壊れていたイベント参加通知メールを修正
- 告知一覧の管理画面カラムに「参加人数 / 定員」を追加表示
- 告知投稿の編集画面メタボックスに参加者一覧を表示

## 詳細

### 1. 参加通知メール修正 (1b6d7df)
`templates/mail/participant.php` および `EventParticipants.php` で以下を修正:
- メールテンプレートのキー誤り（`participants`→`participant`）で参加者名が空欄になっていた
- 旧API遺物の `\$request['status']` 参照（React移行で消えたパラメータ）により、参加状況が常に「不参加」と表示されていた
- DELETE ハンドラーに通知処理が抜けていたため、キャンセル時に主催者へメールが飛ばなかった
- `wp_mail` は plain text 送信なので `<strong>` `<em>` タグを除去

### 2. 管理画面カラム追加 (ee343df)
`AnnouncementHooks::custom_column_content` で `participation` カラムに「参加人数 / 定員」を追記表示。定員が無制限の場合は「N名 / 無制限」と表示。

### 3. メタボックスに参加者一覧を表示 (af55643)
`AnnouncementMetaBox::render()` を override し、募集型イベントの場合のみアバター・表示名・ユーザーページへのリンクをチップ形式で表示。

## Test plan
- [ ] 告知（参加者≠主催者）に参加 → 主催者宛に「新規: 参加」メールが Mailpit に届く
- [ ] 同じユーザーで参加キャンセル → 主催者宛に「更新: 不参加」メールが届く
- [ ] 主催者本人が参加・キャンセル → メール送信されない（仕様通り）
- [ ] `/wp-admin/edit.php?post_type=announcement` で参加人数/定員が表示される
- [ ] 告知投稿編集画面のメタボックスに参加者一覧が表示される（募集型イベントのみ）
- [ ] 「募集はしない」設定の告知ではメタボックス内に参加者一覧が出ない