### PR TITLE
合評会の応募を重複できないようにする (#339)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ wp-config-local.php
 
 # メモ保管場所
 /memo/*
+/tasks/*
 
 # Node dependencies (theme specific)
 /themes/hametuha/node_modules/

--- a/themes/hametuha/functions/campaign.php
+++ b/themes/hametuha/functions/campaign.php
@@ -299,6 +299,54 @@ function hametuha_valid_for_campaign( $campaign_id, $post = null ) {
 }
 
 /**
+ * キャンペーンが重複応募を許可しているか
+ *
+ * 初期値は false（許可しない＝1人1作品）。
+ * タームメタ `_allow_duplicate` が真の場合のみ true。
+ *
+ * @param int|WP_Term $term キャンペーンIDまたはタームオブジェクト
+ * @return bool
+ */
+function hametuha_campaign_allows_duplicate( $term ) {
+	$term_id = is_a( $term, 'WP_Term' ) ? $term->term_id : (int) $term;
+	return (bool) get_term_meta( $term_id, '_allow_duplicate', true );
+}
+
+/**
+ * ユーザーが指定キャンペーンに「別の作品」で既に応募しているか
+ *
+ * 編集中の投稿自身は判定から除外する。
+ *
+ * @param int $campaign_id     キャンペーンID
+ * @param int $user_id         ユーザーID
+ * @param int $exclude_post_id 判定から除外する投稿ID（編集中の投稿自身）
+ * @return bool
+ */
+function hametuha_user_applied_campaign( $campaign_id, $user_id, $exclude_post_id = 0 ) {
+	$user_id = (int) $user_id;
+	if ( ! $user_id ) {
+		return false;
+	}
+	$query = new WP_Query( [
+		'post_type'      => 'post',
+		'post_status'    => 'any',
+		'author'         => $user_id,
+		'posts_per_page' => 1,
+		'no_found_rows'  => true,
+		'fields'         => 'ids',
+		'post__not_in'   => $exclude_post_id ? [ (int) $exclude_post_id ] : [],
+		'tax_query'      => [
+			[
+				'taxonomy' => 'campaign',
+				'field'    => 'term_id',
+				'terms'    => (int) $campaign_id,
+			],
+		],
+	] );
+	return ! empty( $query->posts );
+}
+
+/**
  * ユーザーがキャンペーンに参加しているか
  *
  * @param int      $campaign_id キャンペーンID

--- a/themes/hametuha/hooks/term-campaign.php
+++ b/themes/hametuha/hooks/term-campaign.php
@@ -31,6 +31,7 @@ add_action( 'init', function () {
 				<p class="description">応募できるものはありません。</p>
 				<?php
 			else :
+				$author_id      = (int) $post->post_author ? (int) $post->post_author : get_current_user_id();
 				$term_available = array_filter( $terms, function ( $term ) {
 					return hametuha_is_available_campaign( $term );
 				} );
@@ -54,13 +55,21 @@ add_action( 'init', function () {
 								応募しない
 							</label>
 						</li>
-						<?php foreach ( $term_available as $term ) : ?>
+						<?php
+						foreach ( $term_available as $term ) :
+							// 重複応募不可で、この投稿以外の作品で既に応募済みなら選択不可にする。
+							$already_applied = ! hametuha_campaign_allows_duplicate( $term )
+								&& ! has_term( $term->term_id, 'campaign', $post )
+								&& hametuha_user_applied_campaign( $term->term_id, $author_id, $post->ID );
+							?>
 							<li>
 								<label>
 									<input type="radio" name="tax_input[campaign][]"
-											value="<?php echo esc_attr( $term->term_id ); ?>" <?php checked( has_term( $term->name, $term->taxonomy, $post ) ); ?>/>
+											value="<?php echo esc_attr( $term->term_id ); ?>" <?php checked( has_term( $term->name, $term->taxonomy, $post ) ); ?> <?php disabled( $already_applied ); ?>/>
 									<?php echo esc_html( $term->name ); ?>
-									<?php if ( $limit = get_term_meta( $term->term_id, '_campaign_limit', true ) ) : ?>
+									<?php if ( $already_applied ) : ?>
+										<small>（すでに応募済みです）</small>
+									<?php elseif ( $limit = get_term_meta( $term->term_id, '_campaign_limit', true ) ) : ?>
 										<small><?php echo mysql2date( 'Y年n月j日（D）まで', $limit ); ?></small>
 									<?php else : ?>
 										<small>期限なし</small>
@@ -217,6 +226,20 @@ add_action( 'edit_tag_form_fields', function ( $tag ) {
 				</p>
 			</td>
 		</tr>
+		<tr>
+			<th>
+				重複応募
+			</th>
+			<td>
+				<label style="display: block; margin: 0 1em 1em 0;">
+					<input type="checkbox" name="allow_duplicate" value="1" <?php checked( hametuha_campaign_allows_duplicate( $tag->term_id ) ); ?>/>
+					<?php esc_html_e( '一人が複数の作品を応募できるようにする', 'hametuha' ); ?>
+				</label>
+				<p class="description">
+					<?php esc_html_e( 'チェックを外すと、一人につき一作品しか応募できません（初期値）。', 'hametuha' ); ?>
+				</p>
+			</td>
+		</tr>
 		<?php
 	}
 } );
@@ -241,10 +264,74 @@ add_action( 'edit_terms', function ( $term_id, $taxonomy ) {
 				update_term_meta( $term_id, '_' . $key, $_POST[ $key ] );
 			}
 		}
+		// 重複応募の許可（チェックボックスのため未チェック時は空で保存）
+		update_term_meta( $term_id, '_allow_duplicate', empty( $_POST['allow_duplicate'] ) ? '' : '1' );
 		// Clear cache
 		wp_cache_delete( $term_id, 'campaign_record' );
 	}
 }, 10, 2 );
+
+/**
+ * 重複応募を許可していないキャンペーンへの2作品目の応募を防ぐ
+ *
+ * UIは迂回され得るため、保存時にサーバー側でも検証し、
+ * 重複不可キャンペーンに別作品で既に応募しているユーザーの投稿からは
+ * campaign タームを静かに剥がす。剥がした場合は通知用トランジェントを残す。
+ *
+ * @param int     $post_id 投稿ID
+ * @param WP_Post $post    投稿オブジェクト
+ */
+add_action( 'save_post_post', function ( $post_id, $post ) {
+	if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) ) {
+		return;
+	}
+	$terms = get_the_terms( $post, 'campaign' );
+	if ( ! $terms || is_wp_error( $terms ) ) {
+		return;
+	}
+	$author_id = (int) $post->post_author;
+	$removed   = [];
+	foreach ( $terms as $term ) {
+		if ( hametuha_campaign_allows_duplicate( $term ) ) {
+			continue;
+		}
+		if ( hametuha_user_applied_campaign( $term->term_id, $author_id, $post_id ) ) {
+			wp_remove_object_terms( $post_id, $term->term_id, 'campaign' );
+			$removed[] = $term->name;
+		}
+	}
+	if ( $removed ) {
+		set_transient( 'hametuha_campaign_dup_' . $post_id . '_' . get_current_user_id(), $removed, MINUTE_IN_SECONDS );
+	}
+}, 20, 2 );
+
+/**
+ * 重複応募で campaign タームを剥がした場合、管理画面で通知する
+ */
+add_action( 'admin_notices', function () {
+	$screen = get_current_screen();
+	if ( ! $screen || 'post' !== $screen->base || 'post' !== $screen->post_type ) {
+		return;
+	}
+	global $post;
+	if ( ! $post ) {
+		return;
+	}
+	$key   = 'hametuha_campaign_dup_' . $post->ID . '_' . get_current_user_id();
+	$names = get_transient( $key );
+	if ( ! $names ) {
+		return;
+	}
+	delete_transient( $key );
+	printf(
+		'<div class="notice notice-warning is-dismissible"><p>%s</p></div>',
+		esc_html( sprintf(
+			/* translators: %s: campaign names. */
+			__( '公募「%s」には既に別の作品で応募済みのため、この作品は応募に追加されませんでした。', 'hametuha' ),
+			implode( '」「', $names )
+		) )
+	);
+} );
 
 /**
  * レビューが更新されたらキャッシュ削除

--- a/themes/hametuha/tests/Test_Campaign.php
+++ b/themes/hametuha/tests/Test_Campaign.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * キャンペーン応募の重複制御をテストする
+ *
+ * @package Hametuha
+ * @feature-group campaign
+ */
+
+/**
+ * Campaign duplicate submission test case.
+ */
+class Test_Campaign extends WP_UnitTestCase {
+
+	/**
+	 * Set up
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		// 投稿の publish 遷移で走る分析記録はテスト環境に依存プラグイン
+		// （cookie-tasting）が無く fatal になるため、フックを外す。
+		remove_action( 'transition_post_status', [ \Hametuha\Hooks\RecordEditActions::get_instance(), 'post_transition' ], 10 );
+	}
+
+	/**
+	 * 重複不可のキャンペーンでは、2作品目から campaign タームが剥がされる
+	 */
+	public function test_duplicate_not_allowed() {
+		$user        = $this->factory->user->create();
+		$campaign_id = $this->factory->term->create( [ 'taxonomy' => 'campaign' ] );
+		// 重複応募を許可しない（初期状態）。
+
+		// 1作品目: campaign が付く。
+		$first = $this->factory->post->create( [
+			'post_author' => $user,
+			'post_status' => 'publish',
+		] );
+		wp_set_object_terms( $first, [ (int) $campaign_id ], 'campaign' );
+		$this->assertTrue( has_term( (int) $campaign_id, 'campaign', $first ), '1作品目には応募できる' );
+
+		// 2作品目: save_post 経由で campaign を付与しようとすると剥がされる。
+		$second = $this->factory->post->create( [
+			'post_author' => $user,
+			'post_status' => 'publish',
+			'tax_input'   => [ 'campaign' => [ (int) $campaign_id ] ],
+		] );
+		// factory が tax_input を確実に処理するよう明示的に再保存。
+		wp_set_object_terms( $second, [ (int) $campaign_id ], 'campaign' );
+		wp_update_post( [ 'ID' => $second ] );
+
+		$this->assertFalse( has_term( (int) $campaign_id, 'campaign', $second ), '2作品目は重複応募として剥がされる' );
+	}
+
+	/**
+	 * 重複許可のキャンペーンでは、2作品目も応募できる
+	 */
+	public function test_duplicate_allowed() {
+		$user        = $this->factory->user->create();
+		$campaign_id = $this->factory->term->create( [ 'taxonomy' => 'campaign' ] );
+		update_term_meta( $campaign_id, '_allow_duplicate', '1' );
+
+		$first = $this->factory->post->create( [
+			'post_author' => $user,
+			'post_status' => 'publish',
+		] );
+		wp_set_object_terms( $first, [ (int) $campaign_id ], 'campaign' );
+
+		$second = $this->factory->post->create( [
+			'post_author' => $user,
+			'post_status' => 'publish',
+		] );
+		wp_set_object_terms( $second, [ (int) $campaign_id ], 'campaign' );
+		wp_update_post( [ 'ID' => $second ] );
+
+		$this->assertTrue( has_term( (int) $campaign_id, 'campaign', $first ), '1作品目は応募できる' );
+		$this->assertTrue( has_term( (int) $campaign_id, 'campaign', $second ), '重複許可なら2作品目も応募できる' );
+	}
+
+	/**
+	 * 同じ作品を再保存しても、自分自身は重複とみなされない
+	 */
+	public function test_resave_same_post() {
+		$user        = $this->factory->user->create();
+		$campaign_id = $this->factory->term->create( [ 'taxonomy' => 'campaign' ] );
+
+		$post = $this->factory->post->create( [
+			'post_author' => $user,
+			'post_status' => 'publish',
+		] );
+		wp_set_object_terms( $post, [ (int) $campaign_id ], 'campaign' );
+
+		// 再保存。
+		wp_update_post( [ 'ID' => $post, 'post_title' => '更新後' ] );
+
+		$this->assertTrue( has_term( (int) $campaign_id, 'campaign', $post ), '同じ作品の再保存では剥がされない' );
+	}
+
+	/**
+	 * hametuha_user_applied_campaign のヘルパー単体テスト
+	 */
+	public function test_user_applied_campaign_helper() {
+		$user        = $this->factory->user->create();
+		$other_user  = $this->factory->user->create();
+		$campaign_id = $this->factory->term->create( [ 'taxonomy' => 'campaign' ] );
+
+		$post = $this->factory->post->create( [
+			'post_author' => $user,
+			'post_status' => 'publish',
+		] );
+		wp_set_object_terms( $post, [ (int) $campaign_id ], 'campaign' );
+
+		// 投稿自身を除外すると、別作品はないので false。
+		$this->assertFalse( hametuha_user_applied_campaign( $campaign_id, $user, $post ) );
+		// 除外しなければ true。
+		$this->assertTrue( hametuha_user_applied_campaign( $campaign_id, $user, 0 ) );
+		// 別ユーザーは応募していない。
+		$this->assertFalse( hametuha_user_applied_campaign( $campaign_id, $other_user, 0 ) );
+	}
+
+	/**
+	 * hametuha_campaign_allows_duplicate のヘルパー単体テスト
+	 */
+	public function test_allows_duplicate_helper() {
+		$campaign_id = $this->factory->term->create( [ 'taxonomy' => 'campaign' ] );
+		$this->assertFalse( hametuha_campaign_allows_duplicate( $campaign_id ), '初期値は重複不可' );
+
+		update_term_meta( $campaign_id, '_allow_duplicate', '1' );
+		$this->assertTrue( hametuha_campaign_allows_duplicate( $campaign_id ), 'メタが立てば重複可' );
+	}
+}


### PR DESCRIPTION
## 概要
Issue #339。campaign タグで一人が複数作品を応募できてしまう問題に対応。

campaign タームに「重複応募を許可」タームメタ（`_allow_duplicate`、初期値OFF）を追加し、許可がない限り **1人1作品** しか応募できないようにした。

## 変更
- term編集画面に「重複応募を許可」チェックボックスを追加（初期OFF＝1人1作品）。
- 投稿編集メタボックスで、別作品で応募済みの campaign は **ラジオを `disabled` にし「（すでに応募済みです）」** を表示（自分の応募作品は変更可能）。
- `save_post` でサーバー側でも2作品目の campaign タームを静かに剥がし、`admin_notices` で通知（UI迂回・REST直叩き対策）。
- ヘルパー `hametuha_campaign_allows_duplicate()` / `hametuha_user_applied_campaign()`（編集中の投稿は除外）。
- ユニットテスト `Test_Campaign`（5件）。

## 検証
- `composer test` 全パス、phpcs 追加分クリーン。
- ブラウザ（Chrome MCP）でチェックボックス保存・解除、メタボックスの disabled 表示・自作品の編集可を確認。

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)