### PR TITLE
合評会の当日採点をサイト上で行えるようにする

### DIFF
--- a/themes/hametuha/assets/js/src/components/joint-review-input.jsx
+++ b/themes/hametuha/assets/js/src/components/joint-review-input.jsx
@@ -1,0 +1,158 @@
+/*!
+ * 合評会の当日採点を入力する
+ *
+ * @deps wp-element, wp-api-fetch, wp-i18n, hametuha-toast
+ * @handle hametuha-components-joint-review-input
+ * @strategy defer
+ */
+
+const { createRoot, useState } = wp.element;
+const { __, sprintf } = wp.i18n;
+const apiFetch = wp.apiFetch;
+const { toast } = wp.hametuha;
+
+const EPSILON = 0.001;
+
+/**
+ * 合計を小数誤差を吸収して整形する
+ *
+ * @param {number} value 値
+ * @return {string} 表示用文字列
+ */
+const formatNumber = ( value ) => {
+	return parseFloat( value.toFixed( 2 ) ).toString();
+};
+
+/**
+ * 当日採点入力コンポーネント
+ *
+ * @param {Object} props
+ * @param {number} props.termId       公募タームID
+ * @param {number} props.allotment    持ち点
+ * @param {Array}  props.works        作品一覧 [{ id, title, own }]
+ * @param {Object} props.distribution 現在の配分 { id: point }
+ */
+const JointReviewInput = ( { termId, allotment, works, distribution } ) => {
+	const initial = {};
+	works.forEach( ( work ) => {
+		initial[ work.id ] = work.own ? 0 : parseFloat( distribution[ work.id ] || 0 );
+	} );
+	const [ scores, setScores ] = useState( initial );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	const sum = works.reduce( ( acc, work ) => acc + ( parseFloat( scores[ work.id ] ) || 0 ), 0 );
+	const remaining = allotment - sum;
+	const canSubmit = Math.abs( remaining ) <= EPSILON && ! isSaving;
+
+	/**
+	 * 入力値の変更
+	 *
+	 * @param {number} workId 作品ID
+	 * @param {string} value  入力値
+	 */
+	const handleChange = ( workId, value ) => {
+		const point = value === '' ? 0 : parseFloat( value );
+		setScores( {
+			...scores,
+			[ workId ]: isNaN( point ) || point < 0 ? 0 : point,
+		} );
+	};
+
+	/**
+	 * 採点を送信する
+	 */
+	const handleSubmit = async () => {
+		setIsSaving( true );
+		try {
+			const response = await apiFetch( {
+				path: `/hametuha/v1/campaign/joint-review/${ termId }`,
+				method: 'POST',
+				data: { scores },
+			} );
+			toast( response.message || __( '採点を保存しました。', 'hametuha' ), 'success' );
+		} catch ( error ) {
+			toast( error.message || __( '採点の保存に失敗しました。', 'hametuha' ), 'error' );
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	const remainingClass = Math.abs( remaining ) <= EPSILON ? 'text-success' : 'text-danger';
+
+	return (
+		<div className="joint-review-input">
+			<table className="table joint-review-input__table">
+				<tbody>
+					{ works.map( ( work ) => (
+						<tr key={ work.id }>
+							<th className="joint-review-input__work">{ work.title }</th>
+							<td className="joint-review-input__field">
+								{ work.own ? (
+									<span className="text-muted">{ __( '自作品（採点不可）', 'hametuha' ) }</span>
+								) : (
+									<input
+										type="number"
+										min="0"
+										step="0.1"
+										value={ scores[ work.id ] }
+										onChange={ ( event ) => handleChange( work.id, event.target.value ) }
+										disabled={ isSaving }
+										className="form-control"
+										title={ work.title }
+									/>
+								) }
+							</td>
+						</tr>
+					) ) }
+				</tbody>
+			</table>
+			<p className="joint-review-input__remaining">
+				{ sprintf(
+					/* translators: %1$s: remaining, %2$s: allotment */
+					__( '残り持ち点：%1$s / %2$s', 'hametuha' ),
+					formatNumber( remaining ),
+					formatNumber( allotment )
+				) }
+				<span className={ remainingClass }>
+					{ ' ' }
+					{ Math.abs( remaining ) <= EPSILON
+						? __( '（OK）', 'hametuha' )
+						: __( '（ちょうど使い切ってください）', 'hametuha' ) }
+				</span>
+			</p>
+			<button
+				type="button"
+				className="btn btn-primary"
+				onClick={ handleSubmit }
+				disabled={ ! canSubmit }
+			>
+				{ isSaving ? __( '保存中…', 'hametuha' ) : __( '採点を保存する', 'hametuha' ) }
+			</button>
+		</div>
+	);
+};
+
+// すべてのコンテナを検索してマウントする。
+document.querySelectorAll( '.hametuha-joint-review-input' ).forEach( ( container ) => {
+	const termId = parseInt( container.dataset.termId, 10 );
+	const allotment = parseFloat( container.dataset.allotment ) || 0;
+	let works = [];
+	let distribution = {};
+	try {
+		works = JSON.parse( container.dataset.works || '[]' );
+		distribution = JSON.parse( container.dataset.distribution || '{}' );
+	} catch ( e ) {
+		works = [];
+	}
+
+	if ( termId && works.length ) {
+		createRoot( container ).render(
+			<JointReviewInput
+				termId={ termId }
+				allotment={ allotment }
+				works={ works }
+				distribution={ distribution }
+			/>
+		);
+	}
+} );

--- a/themes/hametuha/functions.php
+++ b/themes/hametuha/functions.php
@@ -98,6 +98,7 @@ require __DIR__ . '/functions/assets-eyecatch.php';
 require __DIR__ . '/functions/assets-tinymce.php';
 // キャンペーン
 require __DIR__ . '/functions/campaign.php';
+require __DIR__ . '/functions/joint-review.php';
 require __DIR__ . '/functions/calculate.php';
 // 表示
 require __DIR__ . '/functions/display.php';

--- a/themes/hametuha/functions/joint-review.php
+++ b/themes/hametuha/functions/joint-review.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * 合評会（当日採点）用関数
+ *
+ * 合評会＝採点のある公募（campaign）で行う当日採点のためのヘルパー群。
+ * セッション状態と参加者はタームメタに、当日点は JointReview モデルに保存する。
+ *
+ * @feature-group joint-review
+ */
+
+/**
+ * 合評会のセッション状態を返す
+ *
+ * '' = 未開催 / 'open' = 入力受付中 / 'published' = 確定・公開
+ *
+ * @param WP_Term|int $term
+ * @return string
+ */
+function hametuha_jr_state( $term ) {
+	$term_id = is_a( $term, 'WP_Term' ) ? $term->term_id : (int) $term;
+	$state   = get_term_meta( $term_id, '_jr_state', true );
+	return in_array( $state, [ 'open', 'published' ], true ) ? $state : '';
+}
+
+/**
+ * 合評会のセッション状態を保存する
+ *
+ * @param int    $term_id
+ * @param string $state '', 'open', 'published'
+ * @return bool
+ */
+function hametuha_jr_set_state( $term_id, $state ) {
+	if ( ! in_array( $state, [ '', 'open', 'published' ], true ) ) {
+		return false;
+	}
+	return (bool) update_term_meta( (int) $term_id, '_jr_state', $state );
+}
+
+/**
+ * 当日参加者の user_id 配列を返す
+ *
+ * @param WP_Term|int $term
+ * @return int[]
+ */
+function hametuha_jr_participants( $term ) {
+	$term_id = is_a( $term, 'WP_Term' ) ? $term->term_id : (int) $term;
+	$ids     = get_term_meta( $term_id, '_jr_participants', true );
+	if ( ! is_array( $ids ) ) {
+		return [];
+	}
+	return array_values( array_unique( array_filter( array_map( 'intval', $ids ) ) ) );
+}
+
+/**
+ * 当日参加者を保存する
+ *
+ * @param int   $term_id
+ * @param int[] $ids
+ * @return bool
+ */
+function hametuha_jr_set_participants( $term_id, $ids ) {
+	$ids = array_values( array_unique( array_filter( array_map( 'intval', (array) $ids ) ) ) );
+	return (bool) update_term_meta( (int) $term_id, '_jr_participants', $ids );
+}
+
+/**
+ * 持ち点（= 参加人数）を返す
+ *
+ * @param WP_Term|int $term
+ * @return int
+ */
+function hametuha_jr_allotment( $term ) {
+	return count( hametuha_jr_participants( $term ) );
+}
+
+/**
+ * ユーザーが当日参加者か
+ *
+ * @param WP_Term|int $term
+ * @param null|int    $user_id
+ * @return bool
+ */
+function hametuha_jr_is_participant( $term, $user_id = null ) {
+	if ( is_null( $user_id ) ) {
+		$user_id = get_current_user_id();
+	}
+	return in_array( (int) $user_id, hametuha_jr_participants( $term ), true );
+}
+
+/**
+ * 作品（campaign の公開投稿）を ID 昇順で返す
+ *
+ * @param WP_Term|int $term
+ * @return array post_id => author_id
+ */
+function hametuha_jr_works( $term ) {
+	$term_id = is_a( $term, 'WP_Term' ) ? $term->term_id : (int) $term;
+	$works   = [];
+	foreach ( get_posts( [
+		'posts_per_page' => -1,
+		'post_status'    => 'publish',
+		'no_found_rows'  => true,
+		'orderby'        => [ 'ID' => 'ASC' ],
+		'tax_query'      => [
+			[
+				'taxonomy' => 'campaign',
+				'field'    => 'term_id',
+				'terms'    => $term_id,
+			],
+		],
+	] ) as $post ) {
+		$works[ (int) $post->ID ] = (int) $post->post_author;
+	}
+	return $works;
+}
+
+/**
+ * あるユーザーの当日点の配分を返す
+ *
+ * @param WP_Term|int $term
+ * @param int         $user_id
+ * @return array post_id => point
+ */
+function hametuha_jr_user_distribution( $term, $user_id ) {
+	$works = hametuha_jr_works( $term );
+	$dist  = array_fill_keys( array_keys( $works ), 0.0 );
+	if ( ! $works ) {
+		return $dist;
+	}
+	$model = \Hametuha\Model\JointReview::get_instance();
+	foreach ( $model->get_user_points( $user_id, array_keys( $works ) ) as $row ) {
+		$dist[ (int) $row->post_id ] = (float) $row->point;
+	}
+	return $dist;
+}
+
+/**
+ * 当日点を入力したユーザーID一覧を返す
+ *
+ * @param WP_Term|int $term
+ * @return int[]
+ */
+function hametuha_jr_voters( $term ) {
+	$works = hametuha_jr_works( $term );
+	if ( ! $works ) {
+		return [];
+	}
+	return \Hametuha\Model\JointReview::get_instance()->voters( array_keys( $works ) );
+}
+
+/**
+ * 当日点の配分を検証する
+ *
+ * @param WP_Term|int $term
+ * @param int         $user_id
+ * @param array       $distribution post_id => point
+ * @return true|WP_Error
+ */
+function hametuha_jr_validate_distribution( $term, $user_id, $distribution ) {
+	$term  = get_term( is_a( $term, 'WP_Term' ) ? $term->term_id : $term, 'campaign' );
+	$error = new WP_Error();
+	if ( ! $term || is_wp_error( $term ) ) {
+		$error->add( 'jr_invalid', __( '公募が見つかりません。', 'hametuha' ) );
+		return $error;
+	}
+	if ( ! hametuha_jr_is_participant( $term, $user_id ) ) {
+		$error->add( 'jr_not_participant', __( '採点に参加できるのは当日参加者のみです。', 'hametuha' ) );
+		return $error;
+	}
+	$works     = hametuha_jr_works( $term );
+	$allotment = hametuha_jr_allotment( $term );
+	$sum       = 0.0;
+	foreach ( $distribution as $post_id => $point ) {
+		$post_id = (int) $post_id;
+		$point   = (float) $point;
+		if ( ! isset( $works[ $post_id ] ) ) {
+			$error->add( 'jr_invalid_post', __( '対象外の作品が含まれています。', 'hametuha' ) );
+			continue;
+		}
+		if ( $point < 0 ) {
+			$error->add( 'jr_negative', __( 'マイナスの点はつけられません。', 'hametuha' ) );
+		}
+		if ( $works[ $post_id ] === (int) $user_id && $point > 0 ) {
+			$error->add( 'jr_own_work', __( '自分の作品には点を入れられません。', 'hametuha' ) );
+		}
+		$sum += $point;
+	}
+	// 合計はちょうど持ち点（小数のため誤差を許容）。
+	if ( abs( $sum - $allotment ) > 0.001 ) {
+		$error->add( 'jr_sum', sprintf(
+			/* translators: %1$s: allotment, %2$s: current sum. */
+			__( '持ち点 %1$s をちょうど使い切ってください（現在 %2$s）。', 'hametuha' ),
+			number_format_i18n( $allotment ),
+			rtrim( rtrim( number_format( $sum, 2 ), '0' ), '.' )
+		) );
+	}
+	return $error->has_errors() ? $error : true;
+}
+
+/**
+ * 当日点の配分を保存する（既存をいったん消して入れ直す）
+ *
+ * @param WP_Term|int $term
+ * @param int         $user_id
+ * @param array       $distribution post_id => point
+ * @return true|WP_Error
+ */
+function hametuha_jr_save_distribution( $term, $user_id, $distribution ) {
+	$valid = hametuha_jr_validate_distribution( $term, $user_id, $distribution );
+	if ( is_wp_error( $valid ) ) {
+		return $valid;
+	}
+	$works = hametuha_jr_works( $term );
+	$model = \Hametuha\Model\JointReview::get_instance();
+	$model->delete_user_points( $user_id, array_keys( $works ) );
+	foreach ( $distribution as $post_id => $point ) {
+		$point   = (float) $point;
+		$post_id = (int) $post_id;
+		if ( $point > 0 && isset( $works[ $post_id ] ) ) {
+			$model->set_point( $user_id, $post_id, $point );
+		}
+	}
+	$term_id = is_a( $term, 'WP_Term' ) ? $term->term_id : (int) $term;
+	wp_cache_delete( $term_id, 'campaign_record' );
+	return true;
+}
+
+/**
+ * 合評会の最終結果を返す（事前点数 + 当日点）
+ *
+ * @param WP_Term|int $term
+ * @return array|WP_Error {
+ *   @type array $works        post_id => author_id
+ *   @type int   $allotment    持ち点
+ *   @type array $participants user_id => [ post_id => point ]（当日点）
+ *   @type array $pre          post_id => 事前点数
+ *   @type array $live         post_id => 当日点合計
+ *   @type array $result       post_id => 事前 + 当日
+ * }
+ */
+function hametuha_joint_review_result( $term ) {
+	$term = get_term( is_a( $term, 'WP_Term' ) ? $term->term_id : $term, 'campaign' );
+	if ( ! $term || is_wp_error( $term ) ) {
+		return new WP_Error( 'jr_invalid', __( '公募が見つかりません。', 'hametuha' ) );
+	}
+	$works = hametuha_jr_works( $term );
+	// 事前点数（content-campaign.php と同じ按分計算）。
+	$pre    = array_fill_keys( array_keys( $works ), 0.0 );
+	$record = hametuha_campaign_record( $term );
+	if ( $record && ! is_wp_error( $record ) && ! empty( $record['participants'] ) ) {
+		foreach ( $record['participants'] as $var ) {
+			if ( empty( $var['rate_total'] ) || $var['rate_total'] <= 0 ) {
+				continue;
+			}
+			foreach ( $works as $post_id => $author ) {
+				$rec              = isset( $var['records'][ $post_id ] ) ? $var['records'][ $post_id ] : 0;
+				$pre[ $post_id ] += ( $var['comment_total'] + 1 ) * $rec / $var['rate_total'];
+			}
+		}
+	}
+	// 当日点。
+	$participants = [];
+	foreach ( hametuha_jr_participants( $term ) as $uid ) {
+		$participants[ $uid ] = array_fill_keys( array_keys( $works ), 0.0 );
+	}
+	$live = array_fill_keys( array_keys( $works ), 0.0 );
+	if ( $works ) {
+		$model = \Hametuha\Model\JointReview::get_instance();
+		foreach ( $model->get_points_for_posts( array_keys( $works ) ) as $row ) {
+			$uid = (int) $row->user_id;
+			$pid = (int) $row->post_id;
+			$pt  = (float) $row->point;
+			if ( ! isset( $participants[ $uid ] ) ) {
+				$participants[ $uid ] = array_fill_keys( array_keys( $works ), 0.0 );
+			}
+			$participants[ $uid ][ $pid ] = $pt;
+			$live[ $pid ]                += $pt;
+		}
+	}
+	$result = [];
+	foreach ( $works as $post_id => $author ) {
+		$result[ $post_id ] = $pre[ $post_id ] + $live[ $post_id ];
+	}
+	return [
+		'works'        => $works,
+		'allotment'    => hametuha_jr_allotment( $term ),
+		'participants' => $participants,
+		'pre'          => $pre,
+		'live'         => $live,
+		'result'       => $result,
+	];
+}

--- a/themes/hametuha/hooks/term-campaign.php
+++ b/themes/hametuha/hooks/term-campaign.php
@@ -218,6 +218,85 @@ add_action( 'edit_tag_form_fields', function ( $tag ) {
 			</td>
 		</tr>
 		<?php
+		// 合評会（当日採点）— 採点のある公募（評価〆切あり）でのみ表示。
+		if ( get_term_meta( $tag->term_id, '_campaign_range_end', true ) ) :
+			$jr_state        = hametuha_jr_state( $tag->term_id );
+			$jr_participants = hametuha_jr_participants( $tag->term_id );
+			$jr_works        = hametuha_jr_works( $tag->term_id );
+			// 候補＝作品著者＋オンライン採点者＋既存の選択者。
+			$jr_candidates = array_values( array_unique( array_values( $jr_works ) ) );
+			$jr_record     = hametuha_campaign_record( $tag->term_id );
+			if ( $jr_record && ! is_wp_error( $jr_record ) && ! empty( $jr_record['participants'] ) ) {
+				$jr_candidates = array_merge( $jr_candidates, array_map( 'intval', array_keys( $jr_record['participants'] ) ) );
+			}
+			$jr_candidates = array_values( array_unique( array_merge( $jr_candidates, $jr_participants ) ) );
+			sort( $jr_candidates );
+			?>
+			<tr>
+				<th>合評会の当日採点</th>
+				<td>
+					<p>
+						<label>状態：
+							<select name="jr_state">
+								<?php
+								foreach ( [
+									''          => '未開催',
+									'open'      => '入力受付中（採点を開始）',
+									'published' => '確定・公開',
+								] as $value => $label ) {
+									printf(
+										'<option value="%s"%s>%s</option>',
+										esc_attr( $value ),
+										selected( $jr_state, $value, false ),
+										esc_html( $label )
+									);
+								}
+								?>
+							</select>
+						</label>
+					</p>
+					<p class="description">
+						持ち点＝参加人数（現在 <strong><?php echo count( $jr_participants ); ?></strong> 名）。
+						作品数 <?php echo count( $jr_works ); ?> 作。
+						入力済み <?php echo count( hametuha_jr_voters( $tag->term_id ) ); ?> 名。
+					</p>
+					<fieldset style="max-height: 200px; overflow-y: auto; border: 1px solid #ccc; padding: .5em 1em;">
+						<legend style="font-weight: bold;">当日参加者（チェックした人だけが採点できます）</legend>
+						<?php if ( empty( $jr_candidates ) ) : ?>
+							<p class="description">候補者がいません。作品が投稿されると候補に表示されます。</p>
+						<?php else : ?>
+							<?php foreach ( $jr_candidates as $candidate_id ) : ?>
+								<?php
+								$candidate = get_userdata( $candidate_id );
+								if ( ! $candidate ) {
+									continue;
+								}
+								$is_author = in_array( (int) $candidate_id, array_map( 'intval', array_values( $jr_works ) ), true );
+								?>
+								<label style="display: inline-block; margin: 0 1em .3em 0;">
+									<input type="checkbox" name="jr_participants[]"
+											value="<?php echo esc_attr( $candidate_id ); ?>"
+											<?php checked( in_array( (int) $candidate_id, $jr_participants, true ) ); ?> />
+									<?php echo esc_html( $candidate->display_name ); ?>
+									<?php if ( $is_author ) : ?>
+										<span class="label label-danger" style="font-size:.7em;">書</span>
+									<?php endif; ?>
+								</label>
+							<?php endforeach; ?>
+						<?php endif; ?>
+					</fieldset>
+					<p style="margin-top:.5em;">
+						<label style="color:#a00;">
+							<input type="checkbox" name="jr_reset" value="1" />
+							当日点をすべてリセットして未開催に戻す
+						</label>
+					</p>
+				</td>
+			</tr>
+			<?php
+		endif;
+		?>
+		<?php
 	}
 } );
 
@@ -239,6 +318,20 @@ add_action( 'edit_terms', function ( $term_id, $taxonomy ) {
 		) {
 			if ( isset( $_POST[ $key ] ) ) {
 				update_term_meta( $term_id, '_' . $key, $_POST[ $key ] );
+			}
+		}
+		// 合評会（当日採点）の設定を保存。
+		if ( isset( $_POST['jr_state'] ) ) {
+			hametuha_jr_set_state( $term_id, sanitize_text_field( wp_unslash( $_POST['jr_state'] ) ) );
+			$jr_participants = isset( $_POST['jr_participants'] ) ? array_map( 'intval', (array) $_POST['jr_participants'] ) : [];
+			hametuha_jr_set_participants( $term_id, $jr_participants );
+			// リセット指定があれば当日点を全削除し未開催に戻す。
+			if ( ! empty( $_POST['jr_reset'] ) ) {
+				$jr_works = hametuha_jr_works( $term_id );
+				if ( $jr_works ) {
+					\Hametuha\Model\JointReview::get_instance()->clear_points( array_keys( $jr_works ) );
+				}
+				hametuha_jr_set_state( $term_id, '' );
 			}
 		}
 		// Clear cache

--- a/themes/hametuha/index.php
+++ b/themes/hametuha/index.php
@@ -104,7 +104,12 @@ get_header( 'breadcrumb' );
 					if ( is_singular( 'lists' ) || is_post_type_archive( 'lists' ) ) {
 						get_template_part( 'parts/nav', 'lists' );
 					} elseif ( is_tax( 'campaign' ) ) {
-						get_template_part( 'parts/content-campaign', get_term_meta( get_queried_object_id(), '_is_collaboration', true ) ? 'collaboration' : '' );
+						if ( hametuha_jr_state( get_queried_object() ) ) {
+							// 合評会の当日採点（入力受付中 or 確定・公開）。
+							get_template_part( 'parts/content-campaign-review' );
+						} else {
+							get_template_part( 'parts/content-campaign', get_term_meta( get_queried_object_id(), '_is_collaboration', true ) ? 'collaboration' : '' );
+						}
 					}
 					// Content
 					if ( ( is_category() || is_tag() || is_tax() ) && ( $content = get_term_meta( get_queried_object_id(), '_term_content', true ) ) ) {

--- a/themes/hametuha/parts/content-campaign-review.php
+++ b/themes/hametuha/parts/content-campaign-review.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * 合評会の当日採点を表示する
+ *
+ * 状態に応じて表示を切り替える。
+ * - open      : 当日参加者には入力フォーム、それ以外には進捗のみ（点数は隠す）
+ * - published : 事前点数＋当日点の結果テーブルを公開（リビール演出）
+ *
+ * @feature-group joint-review
+ */
+
+$jr_term = get_queried_object();
+if ( ! $jr_term || 'campaign' !== $jr_term->taxonomy ) {
+	return;
+}
+$jr_state     = hametuha_jr_state( $jr_term );
+$jr_works     = hametuha_jr_works( $jr_term );
+$jr_allotment = hametuha_jr_allotment( $jr_term );
+$jr_total     = count( hametuha_jr_participants( $jr_term ) );
+$jr_voted     = count( hametuha_jr_voters( $jr_term ) );
+$jr_user_id   = get_current_user_id();
+?>
+
+<div class="campaign-review-live">
+
+<?php if ( 'open' === $jr_state ) : ?>
+
+	<h3 class="campaign-review-live__title">
+		<i class="icon-pencil"></i> <?php esc_html_e( '合評会 採点受付中', 'hametuha' ); ?>
+	</h3>
+
+	<?php if ( ! is_user_logged_in() ) : ?>
+
+		<p class="alert alert-info">
+			<?php
+			printf(
+				/* translators: %s: login url */
+				wp_kses_post( __( '採点状況は<a href="%s" class="alert-link">ログイン</a>すると確認できます。', 'hametuha' ) ),
+				esc_url( wp_login_url( get_term_link( $jr_term ) ) )
+			);
+			?>
+		</p>
+
+	<?php elseif ( hametuha_jr_is_participant( $jr_term, $jr_user_id ) ) : ?>
+
+		<?php
+		// 入力フォーム用のデータを用意する。
+		$jr_works_data = [];
+		foreach ( $jr_works as $jr_post_id => $jr_author ) {
+			$jr_works_data[] = [
+				'id'    => $jr_post_id,
+				'title' => get_the_title( $jr_post_id ),
+				'own'   => ( (int) $jr_author === (int) $jr_user_id ),
+			];
+		}
+		$jr_distribution = hametuha_jr_user_distribution( $jr_term, $jr_user_id );
+		wp_enqueue_script( 'hametuha-components-joint-review-input' );
+		?>
+		<p class="campaign-review-live__lead">
+			<?php
+			printf(
+				/* translators: %s: allotment */
+				esc_html__( 'あなたの持ち点は %s 点です。自分の作品以外に、ちょうど使い切るように配分してください。', 'hametuha' ),
+				'<strong>' . esc_html( number_format_i18n( $jr_allotment ) ) . '</strong>'
+			);
+			?>
+		</p>
+		<div class="hametuha-joint-review-input"
+				data-term-id="<?php echo esc_attr( $jr_term->term_id ); ?>"
+				data-allotment="<?php echo esc_attr( $jr_allotment ); ?>"
+				data-works="<?php echo esc_attr( wp_json_encode( $jr_works_data ) ); ?>"
+				data-distribution="<?php echo esc_attr( wp_json_encode( (object) $jr_distribution ) ); ?>"></div>
+
+	<?php else : ?>
+
+		<p class="alert alert-warning">
+			<?php esc_html_e( '採点できるのは当日参加者のみです。結果の公開をお待ちください。', 'hametuha' ); ?>
+		</p>
+
+	<?php endif; ?>
+
+	<p class="campaign-review-live__progress text-muted">
+		<?php
+		printf(
+			/* translators: %1$d: voted, %2$d: total */
+			esc_html__( '採点入力：%1$d / %2$d 名', 'hametuha' ),
+			(int) $jr_voted,
+			(int) $jr_total
+		);
+		?>
+	</p>
+
+<?php elseif ( 'published' === $jr_state ) : ?>
+
+	<?php
+	$jr_result = hametuha_joint_review_result( $jr_term );
+	if ( is_wp_error( $jr_result ) || empty( $jr_result['works'] ) ) {
+		echo '<p class="alert alert-default">' . esc_html__( '結果がありません。', 'hametuha' ) . '</p>';
+		return;
+	}
+	// 合計（結果）が高い順に作品を並べる。
+	$jr_ordered = $jr_result['result'];
+	arsort( $jr_ordered );
+	$jr_rank = 0;
+	?>
+
+	<h3 class="campaign-review-live__title">
+		<i class="icon-trophy"></i> <?php esc_html_e( '合評会 最終結果', 'hametuha' ); ?>
+	</h3>
+
+	<div class="campaign-score-wrapper">
+		<table class="campaign-score campaign-score--reveal">
+			<caption><?php esc_html_e( '事前点数と当日点の合計', 'hametuha' ); ?></caption>
+			<thead>
+				<tr>
+					<th class="campaign-score-user">&nbsp;</th>
+					<?php foreach ( array_keys( $jr_ordered ) as $jr_post_id ) : ?>
+						<th class="campaign-score-work">
+							<a href="<?php echo esc_url( get_permalink( $jr_post_id ) ); ?>"><?php echo esc_html( get_the_title( $jr_post_id ) ); ?></a>
+						</th>
+					<?php endforeach; ?>
+					<th class="campaign-score-subtotal"><?php esc_html_e( '持ち点', 'hametuha' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $jr_result['participants'] as $jr_uid => $jr_dist ) : ?>
+					<?php
+					$jr_user   = get_userdata( $jr_uid );
+					$jr_sum    = array_sum( $jr_dist );
+					$jr_author = in_array( (int) $jr_uid, array_map( 'intval', array_values( $jr_result['works'] ) ), true );
+					?>
+					<tr style="--jr-row: <?php echo (int) ( $jr_rank++ ); ?>;">
+						<th class="campaign-score-user">
+							<?php echo get_avatar( $jr_uid, 32 ); ?>
+							<span class="campaign-score-user-title">
+								<?php echo esc_html( $jr_user ? $jr_user->display_name : '退会者' ); ?>
+								<?php if ( $jr_author ) : ?>
+									<span class="label label-danger">書</span>
+								<?php else : ?>
+									<span class="label label-default">読</span>
+								<?php endif; ?>
+							</span>
+						</th>
+						<?php foreach ( array_keys( $jr_ordered ) as $jr_post_id ) : ?>
+							<td class="campaign-score-post <?php echo ( (int) $jr_result['works'][ $jr_post_id ] === (int) $jr_uid ) ? 'campaign-score-own' : ''; ?>">
+								<?php echo esc_html( number_format_i18n( isset( $jr_dist[ $jr_post_id ] ) ? $jr_dist[ $jr_post_id ] : 0, 1 ) ); ?>
+							</td>
+						<?php endforeach; ?>
+						<td class="campaign-score-post"><?php echo esc_html( number_format_i18n( $jr_sum, 1 ) ); ?></td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
+			<tfoot>
+				<tr class="campaign-score-pre">
+					<th class="campaign-score-user"><?php esc_html_e( '事前点数', 'hametuha' ); ?></th>
+					<?php foreach ( array_keys( $jr_ordered ) as $jr_post_id ) : ?>
+						<td class="campaign-score-post"><?php echo esc_html( number_format_i18n( $jr_result['pre'][ $jr_post_id ], 1 ) ); ?></td>
+					<?php endforeach; ?>
+					<td>&nbsp;</td>
+				</tr>
+				<tr class="campaign-score-result">
+					<th class="campaign-score-user"><strong><?php esc_html_e( '結果', 'hametuha' ); ?></strong></th>
+					<?php
+					$jr_top = true;
+					foreach ( array_keys( $jr_ordered ) as $jr_post_id ) :
+						?>
+						<td class="campaign-score-post">
+							<strong><?php echo esc_html( number_format_i18n( $jr_result['result'][ $jr_post_id ], 1 ) ); ?></strong>
+							<?php if ( $jr_top ) : ?>
+								<span class="label label-warning">優勝</span>
+								<?php
+								$jr_top = false;
+							endif;
+							?>
+						</td>
+					<?php endforeach; ?>
+					<td>&nbsp;</td>
+				</tr>
+			</tfoot>
+		</table>
+	</div><!-- //.campaign-score-wrapper -->
+
+	<style>
+		.campaign-score--reveal tbody tr {
+			animation: jrFadeIn .4s ease both;
+			animation-delay: calc( var( --jr-row, 0 ) * .12s );
+		}
+		.campaign-score--reveal tfoot .campaign-score-result {
+			animation: jrFadeIn .6s ease both;
+			animation-delay: .8s;
+		}
+		@keyframes jrFadeIn {
+			from { opacity: 0; transform: translateY( .5em ); }
+			to   { opacity: 1; transform: translateY( 0 ); }
+		}
+		@media ( prefers-reduced-motion: reduce ) {
+			.campaign-score--reveal tbody tr,
+			.campaign-score--reveal tfoot .campaign-score-result { animation: none; }
+		}
+	</style>
+
+<?php endif; ?>
+
+</div><!-- //.campaign-review-live -->

--- a/themes/hametuha/parts/content-campaign-review.php
+++ b/themes/hametuha/parts/content-campaign-review.php
@@ -180,7 +180,17 @@ $jr_user_id   = get_current_user_id();
 		</table>
 	</div><!-- //.campaign-score-wrapper -->
 
+	<details class="campaign-review-pre">
+		<summary class="campaign-review-pre__summary"><?php esc_html_e( '事前採点の詳細を見る', 'hametuha' ); ?></summary>
+		<?php
+		// オンライン（事前）採点の内訳テーブル。
+		get_template_part( 'parts/content-campaign' );
+		?>
+	</details>
+
 	<style>
+		.campaign-review-pre { margin-top: 1.5em; }
+		.campaign-review-pre__summary { cursor: pointer; font-weight: bold; }
 		.campaign-score--reveal tbody tr {
 			animation: jrFadeIn .4s ease both;
 			animation-delay: calc( var( --jr-row, 0 ) * .12s );

--- a/themes/hametuha/src/Hametuha/Model/JointReview.php
+++ b/themes/hametuha/src/Hametuha/Model/JointReview.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Hametuha\Model;
+
+
+use WPametu\DB\Model;
+
+/**
+ * 合評会の当日点モデル
+ *
+ * Rating と同じ user_content_relationships テーブルを rel_type='jr_point' で再利用する。
+ * location カラムは decimal(10,9)（整数部1桁）なので、Rating と同様に配点を 1/10 にして
+ * 保存し、読み出し時に 10 倍する（持ち点が 9 を超えても溢れないようにするため）。
+ *
+ * @package Hametuha\Model
+ * @feature-group joint-review
+ * @property-read string $posts
+ */
+class JointReview extends Model {
+
+	/**
+	 * ユーザーとコンテンツを紐づけるテーブル名
+	 *
+	 * @var string
+	 */
+	protected $name = 'user_content_relationships';
+
+	/**
+	 * レコード種別
+	 *
+	 * @var string
+	 */
+	protected $type = 'jr_point';
+
+	/**
+	 * @var string
+	 */
+	protected $primary_key = 'ID';
+
+	/**
+	 * @var string
+	 */
+	protected $updated_column = 'updated';
+
+	/**
+	 * @var array
+	 */
+	protected $default_placeholder = [
+		'ID'        => '%d',
+		'rel_type'  => '%s',
+		'object_id' => '%d',
+		'user_id'   => '%d',
+		'location'  => '%f',
+		'content'   => '%s',
+	];
+
+	/**
+	 * 配点を保存する（なければ追加、あれば更新）
+	 *
+	 * @param int   $user_id
+	 * @param int   $post_id
+	 * @param float $point
+	 * @return false|int
+	 */
+	public function set_point( $user_id, $post_id, $point ) {
+		$where  = [
+			'rel_type'  => $this->type,
+			'object_id' => $post_id,
+			'user_id'   => $user_id,
+		];
+		$exists = $this->select( "{$this->table}.ID" )
+			->wheres( [
+				"{$this->table}.rel_type = %s"  => $this->type,
+				"{$this->table}.user_id = %d"   => $user_id,
+				"{$this->table}.object_id = %d" => $post_id,
+			] )->get_var();
+		if ( is_null( $exists ) ) {
+			return $this->insert( array_merge( $where, [
+				'location' => $point / 10,
+				'content'  => '',
+			] ) );
+		}
+		return $this->update( [ 'location' => $point / 10 ], $where );
+	}
+
+	/**
+	 * あるユーザーの配点を取得する
+	 *
+	 * @param int   $user_id
+	 * @param int[] $post_ids
+	 * @return object[] {post_id, point}
+	 */
+	public function get_user_points( $user_id, $post_ids ) {
+		$post_ids = array_map( 'intval', (array) $post_ids );
+		if ( ! $post_ids ) {
+			return [];
+		}
+		$this->select( 'object_id AS post_id, location * 10 AS point' )
+			->where( 'rel_type = %s', $this->type )
+			->where( 'user_id = %d', $user_id )
+			->where_in( 'object_id', $post_ids, '%d' );
+		return $this->result();
+	}
+
+	/**
+	 * 作品群につけられた全配点を取得する
+	 *
+	 * @param int[] $post_ids
+	 * @return object[] {user_id, post_id, point}
+	 */
+	public function get_points_for_posts( $post_ids ) {
+		$post_ids = array_map( 'intval', (array) $post_ids );
+		if ( ! $post_ids ) {
+			return [];
+		}
+		$this->select( 'user_id, object_id AS post_id, location * 10 AS point' )
+			->where( 'rel_type = %s', $this->type )
+			->where_in( 'object_id', $post_ids, '%d' );
+		return $this->result();
+	}
+
+	/**
+	 * 配点したユーザーID一覧を返す
+	 *
+	 * @param int[] $post_ids
+	 * @return int[]
+	 */
+	public function voters( $post_ids ) {
+		$post_ids = array_map( 'intval', (array) $post_ids );
+		if ( ! $post_ids ) {
+			return [];
+		}
+		$this->select( 'DISTINCT user_id' )
+			->where( 'rel_type = %s', $this->type )
+			->where_in( 'object_id', $post_ids, '%d' );
+		return array_map( 'intval', wp_list_pluck( $this->result(), 'user_id' ) );
+	}
+
+	/**
+	 * ユーザーの配点を削除する
+	 *
+	 * @param int   $user_id
+	 * @param int[] $post_ids
+	 * @return int|false
+	 */
+	public function delete_user_points( $user_id, $post_ids ) {
+		$post_ids = array_map( 'intval', (array) $post_ids );
+		if ( ! $post_ids ) {
+			return 0;
+		}
+		$in = implode( ',', $post_ids );
+		return $this->db->query( $this->db->prepare(
+			"DELETE FROM {$this->table} WHERE rel_type = %s AND user_id = %d AND object_id IN ({$in})",
+			$this->type,
+			$user_id
+		) );
+	}
+
+	/**
+	 * 作品群の配点を全削除する（リセット用）
+	 *
+	 * @param int[] $post_ids
+	 * @return int|false
+	 */
+	public function clear_points( $post_ids ) {
+		$post_ids = array_map( 'intval', (array) $post_ids );
+		if ( ! $post_ids ) {
+			return 0;
+		}
+		$in = implode( ',', $post_ids );
+		return $this->db->query( $this->db->prepare(
+			"DELETE FROM {$this->table} WHERE rel_type = %s AND object_id IN ({$in})",
+			$this->type
+		) );
+	}
+}

--- a/themes/hametuha/src/Hametuha/WpApi/JointReviewScore.php
+++ b/themes/hametuha/src/Hametuha/WpApi/JointReviewScore.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Hametuha\WpApi;
+
+
+use WPametu\API\Rest\WpApi;
+
+/**
+ * 合評会 当日採点 API
+ *
+ * GET  : 状態・自分の配分・進捗を返す
+ * POST : 自分の配分を保存する（当日参加者のみ）
+ *
+ * @package Hametuha\WpApi
+ * @feature-group joint-review
+ */
+class JointReviewScore extends WpApi {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function get_route() {
+		return 'campaign/joint-review/(?P<term_id>\d+)/?';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function get_arguments( $method ) {
+		$args = [
+			'term_id' => [
+				'type'              => 'integer',
+				'description'       => 'Campaign term ID',
+				'required'          => true,
+				'validate_callback' => function ( $term_id ) {
+					$term = get_term( $term_id, 'campaign' );
+					return $term && ! is_wp_error( $term );
+				},
+			],
+		];
+		if ( 'POST' === $method ) {
+			$args['scores'] = [
+				'type'        => 'object',
+				'description' => '作品IDをキー、配点を値とするオブジェクト',
+				'required'    => true,
+			];
+		}
+		return $args;
+	}
+
+	/**
+	 * 状態・自分の配分・進捗を返す
+	 *
+	 * @param \WP_REST_Request $request
+	 * @return \WP_REST_Response
+	 */
+	public function handle_get( \WP_REST_Request $request ) {
+		$term     = get_term( $request->get_param( 'term_id' ), 'campaign' );
+		$user_id  = get_current_user_id();
+		$response = [
+			'state'          => hametuha_jr_state( $term ),
+			'allotment'      => hametuha_jr_allotment( $term ),
+			'voted'          => count( hametuha_jr_voters( $term ) ),
+			'total'          => count( hametuha_jr_participants( $term ) ),
+			'is_participant' => hametuha_jr_is_participant( $term, $user_id ),
+		];
+		if ( $response['is_participant'] ) {
+			$response['distribution'] = (object) hametuha_jr_user_distribution( $term, $user_id );
+		}
+		return new \WP_REST_Response( $response );
+	}
+
+	/**
+	 * 自分の配分を保存する
+	 *
+	 * @param \WP_REST_Request $request
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function handle_post( \WP_REST_Request $request ) {
+		$term = get_term( $request->get_param( 'term_id' ), 'campaign' );
+		if ( 'open' !== hametuha_jr_state( $term ) ) {
+			return new \WP_Error( 'jr_closed', __( '現在この合評会は採点を受け付けていません。', 'hametuha' ), [ 'status' => 403 ] );
+		}
+		$user_id = get_current_user_id();
+		if ( ! hametuha_jr_is_participant( $term, $user_id ) ) {
+			return new \WP_Error( 'jr_not_participant', __( '採点できるのは当日参加者のみです。', 'hametuha' ), [ 'status' => 403 ] );
+		}
+		$scores = (array) $request->get_param( 'scores' );
+		$dist   = [];
+		foreach ( $scores as $post_id => $point ) {
+			$dist[ (int) $post_id ] = (float) $point;
+		}
+		$result = hametuha_jr_save_distribution( $term, $user_id, $dist );
+		if ( is_wp_error( $result ) ) {
+			$result->add_data( [ 'status' => 400 ] );
+			return $result;
+		}
+		return new \WP_REST_Response( [
+			'success' => true,
+			'message' => __( '採点を保存しました。', 'hametuha' ),
+			'voted'   => count( hametuha_jr_voters( $term ) ),
+			'total'   => count( hametuha_jr_participants( $term ) ),
+		] );
+	}
+
+	/**
+	 * ログインユーザーのみ
+	 *
+	 * @param \WP_REST_Request $request
+	 * @return bool
+	 */
+	public function permission_callback( $request ) {
+		return is_user_logged_in();
+	}
+}

--- a/themes/hametuha/tests/Test_JointReview.php
+++ b/themes/hametuha/tests/Test_JointReview.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * 合評会 当日採点のテスト
+ *
+ * @package Hametuha
+ * @feature-group joint-review
+ */
+
+/**
+ * Joint review live scoring test case.
+ */
+class Test_JointReview extends WP_UnitTestCase {
+
+	/**
+	 * @var int campaign term id
+	 */
+	private $term_id;
+
+	/**
+	 * @var array post_id => author user_id
+	 */
+	private $works = [];
+
+	/**
+	 * @var int[] participant user ids（a1, a2, a3, reader）
+	 */
+	private $participants = [];
+
+	/**
+	 * テスト用に user_content_relationships テーブルを一度だけ作成する。
+	 *
+	 * @param \WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		global $wpdb;
+		$table = $wpdb->prefix . 'user_content_relationships';
+		// phpcs:ignore WordPress.DB
+		$wpdb->query(
+			"CREATE TABLE IF NOT EXISTS {$table} (
+				ID bigint unsigned NOT NULL AUTO_INCREMENT,
+				rel_type varchar(10) NOT NULL DEFAULT 'favorite',
+				object_id bigint unsigned NOT NULL,
+				user_id bigint unsigned NOT NULL,
+				location decimal(10,9) NOT NULL,
+				content text NOT NULL,
+				updated datetime NOT NULL,
+				PRIMARY KEY (ID),
+				KEY user (rel_type,object_id,user_id)
+			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+		);
+	}
+
+	/**
+	 * Set up
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		// publish 遷移で走る分析記録（依存プラグインなし）でfatalになるためフックを外す。
+		remove_action( 'transition_post_status', [ \Hametuha\Hooks\RecordEditActions::get_instance(), 'post_transition' ], 10 );
+
+		// 採点のある公募（評価〆切あり）。
+		$this->term_id = $this->factory->term->create( [ 'taxonomy' => 'campaign' ] );
+		update_term_meta( $this->term_id, '_campaign_range_end', '2030-01-01' );
+
+		// 著者3名＋作品3作、読み専1名 → 参加者4名（持ち点N=4）。
+		$a1     = $this->factory->user->create();
+		$a2     = $this->factory->user->create();
+		$a3     = $this->factory->user->create();
+		$reader = $this->factory->user->create();
+		foreach ( [ $a1, $a2, $a3 ] as $author ) {
+			$pid = $this->factory->post->create( [
+				'post_author' => $author,
+				'post_status' => 'publish',
+			] );
+			wp_set_object_terms( $pid, [ (int) $this->term_id ], 'campaign' );
+			$this->works[ $pid ] = $author;
+		}
+		$this->participants = [ $a1, $a2, $a3, $reader ];
+		hametuha_jr_set_participants( $this->term_id, $this->participants );
+		hametuha_jr_set_state( $this->term_id, 'open' );
+	}
+
+	/**
+	 * 状態・参加者・持ち点の基本動作
+	 */
+	public function test_state_participants_allotment() {
+		$this->assertSame( 'open', hametuha_jr_state( $this->term_id ) );
+		$this->assertSame( 4, hametuha_jr_allotment( $this->term_id ) );
+		$this->assertCount( 3, hametuha_jr_works( $this->term_id ) );
+		$this->assertTrue( hametuha_jr_is_participant( $this->term_id, $this->participants[0] ) );
+		$this->assertFalse( hametuha_jr_is_participant( $this->term_id, 999999 ) );
+	}
+
+	/**
+	 * 配分の検証ロジック
+	 */
+	public function test_validation() {
+		$work_ids = array_keys( $this->works );
+		$reader   = $this->participants[3];
+		// 合計ちょうどN=4 → OK
+		$ok = [ $work_ids[0] => 2, $work_ids[1] => 1, $work_ids[2] => 1 ];
+		$this->assertTrue( hametuha_jr_validate_distribution( $this->term_id, $reader, $ok ) );
+
+		// 合計が足りない → エラー
+		$short = [ $work_ids[0] => 1, $work_ids[1] => 1, $work_ids[2] => 1 ];
+		$this->assertWPError( hametuha_jr_validate_distribution( $this->term_id, $reader, $short ) );
+
+		// 自作品に点を入れる → エラー（a1 が自分の作品 work_ids[0] に入れる）
+		$a1  = $this->participants[0];
+		$own = [ $work_ids[0] => 2, $work_ids[1] => 1, $work_ids[2] => 1 ];
+		$this->assertWPError( hametuha_jr_validate_distribution( $this->term_id, $a1, $own ) );
+
+		// 非参加者 → エラー
+		$stranger = $this->factory->user->create();
+		$this->assertWPError( hametuha_jr_validate_distribution( $this->term_id, $stranger, $ok ) );
+	}
+
+	/**
+	 * 小数も許可される
+	 */
+	public function test_validation_allows_decimal() {
+		$work_ids = array_keys( $this->works );
+		$reader   = $this->participants[3];
+		$decimal  = [ $work_ids[0] => 1.6, $work_ids[1] => 1.2, $work_ids[2] => 1.2 ];
+		$this->assertTrue( hametuha_jr_validate_distribution( $this->term_id, $reader, $decimal ) );
+	}
+
+	/**
+	 * 保存と集計（事前点数なし → 結果 = 当日点）
+	 */
+	public function test_save_and_result() {
+		$work_ids = array_keys( $this->works );
+		list( $w1, $w2, $w3 ) = $work_ids;
+		list( $a1, $a2, $a3, $reader ) = $this->participants;
+
+		$this->assertTrue( hametuha_jr_save_distribution( $this->term_id, $reader, [ $w1 => 2, $w2 => 1, $w3 => 1 ] ) );
+		$this->assertTrue( hametuha_jr_save_distribution( $this->term_id, $a1, [ $w2 => 2, $w3 => 2 ] ) );
+		$this->assertTrue( hametuha_jr_save_distribution( $this->term_id, $a2, [ $w1 => 2, $w3 => 2 ] ) );
+		$this->assertTrue( hametuha_jr_save_distribution( $this->term_id, $a3, [ $w1 => 2, $w2 => 2 ] ) );
+
+		$this->assertCount( 4, hametuha_jr_voters( $this->term_id ) );
+
+		$result = hametuha_joint_review_result( $this->term_id );
+		$this->assertFalse( is_wp_error( $result ) );
+		// live: w1 = 2+2+2 = 6, w2 = 1+2+2 = 5, w3 = 1+2+2 = 5
+		$this->assertEqualsWithDelta( 6, $result['live'][ $w1 ], 0.001 );
+		$this->assertEqualsWithDelta( 5, $result['live'][ $w2 ], 0.001 );
+		$this->assertEqualsWithDelta( 5, $result['live'][ $w3 ], 0.001 );
+		// 事前点数なし → result == live
+		$this->assertEqualsWithDelta( 6, $result['result'][ $w1 ], 0.001 );
+		// 合計は持ち点 × 人数 = 16
+		$this->assertEqualsWithDelta( 16, array_sum( $result['live'] ), 0.001 );
+	}
+
+	/**
+	 * 再送信で上書きされる（重複しない）
+	 */
+	public function test_resubmit_overwrites() {
+		$work_ids = array_keys( $this->works );
+		list( $w1, $w2, $w3 ) = $work_ids;
+		$reader = $this->participants[3];
+
+		hametuha_jr_save_distribution( $this->term_id, $reader, [ $w1 => 4 ] );
+		$dist = hametuha_jr_user_distribution( $this->term_id, $reader );
+		$this->assertEqualsWithDelta( 4, $dist[ $w1 ], 0.001 );
+
+		// 入れ直し
+		hametuha_jr_save_distribution( $this->term_id, $reader, [ $w2 => 4 ] );
+		$dist = hametuha_jr_user_distribution( $this->term_id, $reader );
+		$this->assertEqualsWithDelta( 0, $dist[ $w1 ], 0.001 );
+		$this->assertEqualsWithDelta( 4, $dist[ $w2 ], 0.001 );
+	}
+
+	/**
+	 * モデルの小数往復（point/10で保存し10倍で読む）
+	 */
+	public function test_model_decimal_roundtrip() {
+		$work_ids = array_keys( $this->works );
+		$reader   = $this->participants[3];
+		$model    = \Hametuha\Model\JointReview::get_instance();
+		$model->set_point( $reader, $work_ids[0], 2.8 );
+		$rows = $model->get_user_points( $reader, [ $work_ids[0] ] );
+		$this->assertCount( 1, $rows );
+		$this->assertEqualsWithDelta( 2.8, (float) $rows[0]->point, 0.001 );
+	}
+}


### PR DESCRIPTION
## 概要
合評会（採点のある公募）の **当日採点** を、これまで手動スプレッドシートで行っていたものをサイト上で完結できるようにした。

## 仕様
- セッション状態（未開催→入力受付中→確定・公開）と当日参加者を campaign のタームメタで管理。管理者が term 編集画面で**参加者選択・状態切替・リセット**。
- 持ち点＝参加人数。自作品以外に合計ちょうど配分（小数可）をサーバー側で検証。
- **入力中は集計を隠し**各参加者が自端末で入力 → **確定で結果を公開**（事前点数＋当日点＝結果、リビール演出）。
- 確定後は事前採点の詳細表を `<details>` トグルで表示。

## 実装
- `Model/JointReview` — `user_content_relationships` を `rel_type=jr_point` で再利用。`location` が `decimal(10,9)`（整数部1桁）のため配点を **1/10 で保存・×10 で読み出し**（溢れ防止）。
- `WpApi/JointReviewScore` — GET（状態・自分の配分・進捗）/ POST（保存・当日参加者限定）。
- `functions/joint-review.php`、`parts/content-campaign-review.php`、`assets/js/src/components/joint-review-input.jsx`、`hooks/term-campaign.php`（管理UI）、`index.php`（分岐）。
- ユニットテスト `Test_JointReview`（6件）。

## 検証
- `composer test` 全18件パス、phpcs 追加分クリーン。
- ブラウザ（Chrome MCP）で管理UI・入力フォーム（自作品不可・残点・送信）・保存（point/10格納）・結果表（優勝バッジ・対角グレー）・事前採点トグルを確認。

## 注意
- ビルド成果物（dist / wp-dependencies.json）はgitignoreのため、デプロイ時のCIビルド前提。

🤖 Generated with [Claude Code](https://claude.com/claude-code)