### PR TITLE
is_numeric を validate_callback に直接渡す不具合を修正 (#337)

### DIFF
--- a/themes/hametuha/src/Hametuha/WpApi/IdeasMine.php
+++ b/themes/hametuha/src/Hametuha/WpApi/IdeasMine.php
@@ -20,7 +20,11 @@ class IdeasMine extends IdeaApiPattern {
 			case 'GET':
 				return [
 					'offset' => [
-						'validate_callback' => 'is_numeric',
+						'validate_callback' => function ( $var ) {
+							// REST のコールバックは ( $value, $request, $param ) の3引数で呼ばれるため、
+							// 1引数しか取らない is_numeric を直接渡すと ArgumentCountError になる。
+							return is_numeric( $var );
+						},
 						'default'           => 0,
 					],
 					's'      => [

--- a/themes/hametuha/tests/Test_IdeasMine.php
+++ b/themes/hametuha/tests/Test_IdeasMine.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * idea/mine の REST 引数バリデーションのテスト
+ *
+ * @package Hametuha
+ */
+
+/**
+ * Regression test for #337.
+ *
+ * REST の validate_callback は ( $value, $request, $param ) の3引数で呼ばれるため、
+ * 1引数しか取らない 'is_numeric' を直接渡すと ArgumentCountError で Fatal になっていた。
+ */
+class Test_IdeasMine extends WP_UnitTestCase {
+
+	/**
+	 * offset の validate_callback が3引数で呼ばれても落ちず、正しく判定する
+	 */
+	public function test_offset_validate_callback_accepts_three_args() {
+		$api = new \Hametuha\WpApi\IdeasMine();
+		$ref = new ReflectionMethod( $api, 'get_arguments' );
+		$ref->setAccessible( true );
+		$args = $ref->invoke( $api, 'GET' );
+
+		$this->assertArrayHasKey( 'offset', $args );
+		$callback = $args['offset']['validate_callback'];
+		$this->assertIsCallable( $callback );
+
+		$request = new WP_REST_Request( 'GET', '/hametuha/v1/idea/mine' );
+		// WordPress コアと同じく ( $value, $request, $param ) の3引数で呼び出す。
+		$this->assertTrue( call_user_func( $callback, '5', $request, 'offset' ), '数値は通る' );
+		$this->assertFalse( (bool) call_user_func( $callback, 'abc', $request, 'offset' ), '非数値は弾く' );
+	}
+}


### PR DESCRIPTION
## 概要
Issue #337。`idea/mine` の GET ルートで `offset` パラメータの `validate_callback` に文字列 `'is_numeric'` を渡していた。

WordPress REST はコールバックを `( $value, $request, $param )` の **3引数** で呼ぶため、引数を1つしか取らない `is_numeric()` が `ArgumentCountError: is_numeric() expects exactly 1 argument, 3 given` で Fatal になっていた。

`offset` が明示的に渡された時（ページング時）のみ発生するため、低頻度（6週で1件）という症状とも一致する。

## 原因箇所
`themes/hametuha/src/Hametuha/WpApi/IdeasMine.php`
```php
'offset' => [
    'validate_callback' => 'is_numeric', // ← 3引数で呼ばれて Fatal
    'default'           => 0,
],
```

## 修正
周囲の他パラメータと同じくクロージャでラップし、値だけを `is_numeric()` に渡すようにした。

## 検証
- 回帰テスト `Test_IdeasMine` を追加（validate_callback を3引数で呼んでも落ちず、数値/非数値を正しく判定）。
- `composer test` 全24件パス。phpcs 追加分クリーン。
- 他に `is_numeric` を文字列コールバックとして渡している箇所がないことを grep で確認済み（このファイルのみ）。

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)