### PR TITLE
hampost compile: 注番号をルビ形式で出力＋書式を --note-format で指定可能に

### DIFF
--- a/themes/hametuha/src/Hametuha/Commands/Post.php
+++ b/themes/hametuha/src/Hametuha/Commands/Post.php
@@ -15,6 +15,13 @@ class Post extends Command {
 	const COMMAND_NAME = 'hampost';
 
 	/**
+	 * 本文注番号のデフォルト書式（sprintf）。
+	 *
+	 * 縦書きでは半角アスタリスクが正しく反応しないため、全角アスタリスクを既定とする。
+	 */
+	const DEFAULT_NOTE_FORMAT = '＊%d';
+
+	/**
 	 * Show statistic for specific condition
 	 *
 	 * ## OPTIONS
@@ -84,7 +91,11 @@ class Post extends Command {
 	 * : [--endmark-string=<endmark-string>]
 	 *   Set to change default endmark "——了"
 	 *
-	 * @synopsis <taxonomy> <term> [--format=<format>] [--endmark] [--endmark-string=<endmark-string>]
+	 * : [--note-format=<note-format>]
+	 *   text 書き出し時の注番号の sprintf 書式。%d が番号に置換される。
+	 *   既定は "＊%d"（全角アスタリスク）。例: "［%d］", "†%d"
+	 *
+	 * @synopsis <taxonomy> <term> [--format=<format>] [--endmark] [--endmark-string=<endmark-string>] [--note-format=<note-format>]
 	 * @param array $args
 	 * @param array $assoc
 	 */
@@ -93,6 +104,11 @@ class Post extends Command {
 		$format                     = $assoc['format'] ?? 'xml';
 		if ( ! in_array( $format, [ 'xml', 'text', 'plain', 'tags', 'csv' ] ) ) {
 			self::e( sprintf( 'Format %s is wrong.', $format ) );
+		}
+		// 注番号の書式（text 書き出しで使用）。%d が番号に置換される。
+		$note_format = $assoc['note-format'] ?? self::DEFAULT_NOTE_FORMAT;
+		if ( ! preg_match( '/%[\'\-0-9.]*d/', $note_format ) ) {
+			self::e( sprintf( 'Note format "%s" must contain a %%d placeholder (e.g. ＊%%d, ［%%d］).', $note_format ) );
 		}
 		// End mark.
 		$endmark = ! empty( $assoc['endmark'] ) ? '<p style="text-align: right">——了</p>' : '';
@@ -183,7 +199,7 @@ class Post extends Command {
 					$export_post->post_content = $content_with_notes;
 
 					// Post content.
-					$tagged_text = "<UNICODE-MAC>\n" . $this->to_text( $export_post, $endmark );
+					$tagged_text = "<UNICODE-MAC>\n" . $this->to_text( $export_post, $endmark, $note_format );
 					file_put_contents( "{$dir}/post-{$post->ID}.txt", mb_convert_encoding( str_replace( "\n", "\r", $tagged_text ), 'UTF-16BE', 'utf-8' ) );
 					self::l( sprintf( '#%1$d %3$s「%2$s」', $post->ID, get_the_title( $post ), get_the_author_meta( 'display_name', $post->post_author ) ) );
 					// Footernotes.
@@ -196,7 +212,7 @@ class Post extends Command {
 					} else {
 						$note_post = $export_post;
 					}
-					$footernote = $this->to_footernote_text( $note_post );
+					$footernote = $this->to_footernote_text( $note_post, $note_format );
 					if ( $footernote ) {
 						file_put_contents( "{$dir}/post-{$post->ID}-footernote.txt", mb_convert_encoding( str_replace( "\n", "\r", $footernote ), 'UTF-16BE', 'utf-8' ) );
 					}
@@ -276,7 +292,7 @@ class Post extends Command {
 				$content_post = new \WP_Post( (object) [ 'post_content' => $content, 'filter' => 'raw' ] );
 				switch ( $format ) {
 					case 'text':
-						$tagged_text = "<UNICODE-MAC>\n" . $this->to_text( $content_post );
+						$tagged_text = "<UNICODE-MAC>\n" . $this->to_text( $content_post, '', $note_format );
 						file_put_contents( "{$dir}/series-{$label}.txt", mb_convert_encoding( str_replace( "\n", "\r", $tagged_text ), 'UTF-16BE', 'utf-8' ) );
 						self::l( sprintf( 'series %s saved.', $label ) );
 						break;
@@ -324,12 +340,13 @@ class Post extends Command {
 	/**
 	 * Get tagged text for InDesign.
 	 *
-	 * @param null|int|\WP_Post $post    Post object to compile.
-	 * @param string            $endmark Add endmark if set.
+	 * @param null|int|\WP_Post $post        Post object to compile.
+	 * @param string            $endmark     Add endmark if set.
+	 * @param string            $note_format 注番号の sprintf 書式（%d が番号に置換される）。
 	 *
 	 * @return string
 	 */
-	protected function to_text( $post = null, $endmark = '' ) {
+	protected function to_text( $post = null, $endmark = '', $note_format = self::DEFAULT_NOTE_FORMAT ) {
 		$post = get_post( $post );
 		// Fix double space.
 		$content = str_replace( "\r\n", "\n", $post->post_content );
@@ -351,14 +368,15 @@ class Post extends Command {
 		}
 		// Convert Footernote.
 		// InDesign では文字スタイルだけの注番号を組版上の注番号にできないため、
-		// 半角スペースを親文字（FooterNoteRef で圧縮）にし、注番号 *N をそのルビとして付ける。
+		// 半角スペースを親文字（FooterNoteRef で圧縮）にし、注番号をそのルビとして付ける。
 		// こうすると前後の文脈に依存せず、リンク由来・通常脚注のどちらも同一形式で確実に出せる。
+		// 注番号の見た目（＊/［］/ダガー等）は $note_format で切り替えられる。
 		$note_id = 0;
-		$content = preg_replace_callback( '#<small class="footernote-ref">(.*?)</small>#u', function ( $matches ) use ( &$note_id ) {
+		$content = preg_replace_callback( '#<small class="footernote-ref">(.*?)</small>#u', function ( $matches ) use ( &$note_id, $note_format ) {
 			$note_id++;
 			return sprintf(
-				'<cMojiRuby:0><cRuby:1><cRubyString:*%d><CharStyle:FooterNoteRef> <CharStyle:><cMojiRuby:><cRuby:><cRubyString:>',
-				$note_id
+				'<cMojiRuby:0><cRuby:1><cRubyString:%s><CharStyle:FooterNoteRef> <CharStyle:><cMojiRuby:><cRuby:><cRubyString:>',
+				sprintf( $note_format, $note_id )
 			);
 		}, $content );
 
@@ -448,13 +466,15 @@ class Post extends Command {
 	 * 脚注を InDesign タグ付きテキストとして生成する。
 	 *
 	 * hametuha_footer_notes() が生成する脚注 HTML（自動生成・_footernotes メタ双方に対応）を
-	 * 解析し、各項目を `<ParaStyle:FooterNote><CharStyle:FooterNoteRef>*N<CharStyle:>本文` の
-	 * 1 行に変換する。本文の *N と番号が一致する。脚注が無ければ空文字を返す。
+	 * 解析し、各項目を `<ParaStyle:FooterNote><CharStyle:FooterNoteRef>{注番号}<CharStyle:>本文` の
+	 * 1 行に変換する。注番号は本文側と同じ $note_format を使うため見た目が一致する。
+	 * 脚注が無ければ空文字を返す。
 	 *
-	 * @param int|\WP_Post $note_post 脚注生成に使う投稿。
+	 * @param int|\WP_Post $note_post   脚注生成に使う投稿。
+	 * @param string       $note_format 注番号の sprintf 書式（%d が番号に置換される）。
 	 * @return string タグ付きテキスト（<UNICODE-MAC> ヘッダ付き）。脚注が無ければ空文字。
 	 */
-	protected function to_footernote_text( $note_post ) {
+	protected function to_footernote_text( $note_post, $note_format = self::DEFAULT_NOTE_FORMAT ) {
 		ob_start();
 		hametuha_footer_notes( '', '', '', $note_post );
 		$html = trim( ob_get_clean() );
@@ -476,7 +496,7 @@ class Post extends Command {
 			if ( '' === $item ) {
 				continue;
 			}
-			$lines[] = sprintf( '<ParaStyle:FooterNote><CharStyle:FooterNoteRef>*%d<CharStyle:>%s', $index + 1, $item );
+			$lines[] = sprintf( '<ParaStyle:FooterNote><CharStyle:FooterNoteRef>%s<CharStyle:>%s', sprintf( $note_format, $index + 1 ), $item );
 		}
 		return empty( $lines ) ? '' : "<UNICODE-MAC>\n" . implode( "\n", $lines );
 	}

--- a/themes/hametuha/src/Hametuha/Commands/Post.php
+++ b/themes/hametuha/src/Hametuha/Commands/Post.php
@@ -350,10 +350,16 @@ class Post extends Command {
 			$content .= "\n" . $endmark;
 		}
 		// Convert Footernote.
+		// InDesign では文字スタイルだけの注番号を組版上の注番号にできないため、
+		// 半角スペースを親文字（FooterNoteRef で圧縮）にし、注番号 *N をそのルビとして付ける。
+		// こうすると前後の文脈に依存せず、リンク由来・通常脚注のどちらも同一形式で確実に出せる。
 		$note_id = 0;
 		$content = preg_replace_callback( '#<small class="footernote-ref">(.*?)</small>#u', function ( $matches ) use ( &$note_id ) {
 			$note_id++;
-			return sprintf( '<CharStyle:FooterNoteRef>*%d<CharStyle:>', $note_id );
+			return sprintf(
+				'<cMojiRuby:0><cRuby:1><cRubyString:*%d><CharStyle:FooterNoteRef> <CharStyle:><cMojiRuby:><cRuby:><cRubyString:>',
+				$note_id
+			);
 		}, $content );
 
 		// Inline elements and dashes.

--- a/themes/hametuha/tests/Test_Post_Compile.php
+++ b/themes/hametuha/tests/Test_Post_Compile.php
@@ -175,11 +175,24 @@ class Test_Post_Compile extends WP_UnitTestCase {
 		$post   = new WP_Post( (object) [ 'post_content' => $this->inject( $html ), 'filter' => 'raw' ] );
 		$result = $this->to_text->invoke( $this->command, $post );
 
-		// アンカーテキストは残り、URL は *1 の脚注参照になる。
-		$this->assertStringContainsString( 'リンク<CharStyle:FooterNoteRef>*1<CharStyle:>', $result );
+		// アンカーテキストは残り、URL は *1 の注番号（半角スペース親文字＋ルビ）になる。
+		$this->assertStringContainsString( 'リンク' . $this->body_ref( 1 ), $result );
 		// 生のリンクタグや URL は本文に残らない。
 		$this->assertStringNotContainsString( '<a ', $result );
 		$this->assertStringNotContainsString( 'https://example.com', $result );
+	}
+
+	/**
+	 * 本文中に出力される注番号（半角スペースを親文字にしたルビ）の期待値。
+	 *
+	 * @param int $n 注番号。
+	 * @return string
+	 */
+	protected function body_ref( $n ) {
+		return sprintf(
+			'<cMojiRuby:0><cRuby:1><cRubyString:*%d><CharStyle:FooterNoteRef> <CharStyle:><cMojiRuby:><cRuby:><cRubyString:>',
+			$n
+		);
 	}
 
 	/**
@@ -198,9 +211,9 @@ class Test_Post_Compile extends WP_UnitTestCase {
 
 		// 本文側: 文書順で *1（既存脚注）→ *2（リンク）→ *3（既存脚注）。
 		$body = $this->to_text->invoke( $this->command, $post );
-		$this->assertStringContainsString( '<CharStyle:FooterNoteRef>*1<CharStyle:>', $body );
-		$this->assertStringContainsString( 'リンク<CharStyle:FooterNoteRef>*2<CharStyle:>', $body );
-		$this->assertStringContainsString( '<CharStyle:FooterNoteRef>*3<CharStyle:>', $body );
+		$this->assertStringContainsString( $this->body_ref( 1 ), $body );
+		$this->assertStringContainsString( 'リンク' . $this->body_ref( 2 ), $body );
+		$this->assertStringContainsString( $this->body_ref( 3 ), $body );
 
 		// リスト側: 同じ文書順で 3 項目生成され、2 番目にリンク URL が入る。
 		$notes = hametuha_get_footer_notes( $post );
@@ -210,6 +223,22 @@ class Test_Post_Compile extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'https://example.com/link', $notes );
 		$this->assertStringContainsString( 'id="footernote-3"', $notes );
 		$this->assertStringContainsString( '二つ目の脚注', $notes );
+	}
+
+	/**
+	 * 通常脚注の本文注番号が、半角スペースを親文字にしたルビ形式で出力されること。
+	 *
+	 * InDesign で注番号（組版）にするための形式。文字スタイルのみの旧形式は使わない。
+	 */
+	public function test_body_footernote_ref_is_ruby_over_space() {
+		$html   = '本文<small class="footernote-ref">脚注</small>。';
+		$post   = new WP_Post( (object) [ 'post_content' => $html, 'filter' => 'raw' ] );
+		$result = $this->to_text->invoke( $this->command, $post );
+
+		// 親文字＝半角スペース、ルビ＝*1。
+		$this->assertStringContainsString( '本文' . $this->body_ref( 1 ), $result );
+		// 旧形式（文字スタイルのみの注番号）は残らない。
+		$this->assertStringNotContainsString( '<CharStyle:FooterNoteRef>*1<CharStyle:>', $result );
 	}
 
 	/**

--- a/themes/hametuha/tests/Test_Post_Compile.php
+++ b/themes/hametuha/tests/Test_Post_Compile.php
@@ -57,12 +57,17 @@ class Test_Post_Compile extends WP_UnitTestCase {
 	/**
 	 * 本文（リンク変換済み）から脚注タグ付きテキストを生成する。
 	 *
-	 * @param string $html 変換前の本文 HTML。
+	 * @param string      $html   変換前の本文 HTML。
+	 * @param string|null $format 注番号書式（null で既定）。
 	 * @return string
 	 */
-	protected function footernote_text( $html ) {
+	protected function footernote_text( $html, $format = null ) {
 		$post = new WP_Post( (object) [ 'post_content' => $this->inject( $html ), 'filter' => 'raw' ] );
-		return $this->footernote->invoke( $this->command, $post );
+		$args = [ $this->command, $post ];
+		if ( null !== $format ) {
+			$args[] = $format;
+		}
+		return $this->footernote->invokeArgs( $this->command, array_slice( $args, 1 ) );
 	}
 
 	/**
@@ -88,6 +93,18 @@ class Test_Post_Compile extends WP_UnitTestCase {
 		// compile() の序文パスと同じ形（filter=raw で合成 WP_Post を作る）。
 		$post = new WP_Post( (object) [ 'post_content' => $html, 'filter' => 'raw' ] );
 		return $this->to_text->invoke( $this->command, $post );
+	}
+
+	/**
+	 * 注番号書式を指定して to_text() に通す。
+	 *
+	 * @param string $html
+	 * @param string $format 注番号書式。
+	 * @return string
+	 */
+	protected function convert_with_format( $html, $format ) {
+		$post = new WP_Post( (object) [ 'post_content' => $this->inject( $html ), 'filter' => 'raw' ] );
+		return $this->to_text->invoke( $this->command, $post, '', $format );
 	}
 
 	/**
@@ -188,10 +205,10 @@ class Test_Post_Compile extends WP_UnitTestCase {
 	 * @param int $n 注番号。
 	 * @return string
 	 */
-	protected function body_ref( $n ) {
+	protected function body_ref( $n, $format = '＊%d' ) {
 		return sprintf(
-			'<cMojiRuby:0><cRuby:1><cRubyString:*%d><CharStyle:FooterNoteRef> <CharStyle:><cMojiRuby:><cRuby:><cRubyString:>',
-			$n
+			'<cMojiRuby:0><cRuby:1><cRubyString:%s><CharStyle:FooterNoteRef> <CharStyle:><cMojiRuby:><cRuby:><cRubyString:>',
+			sprintf( $format, $n )
 		);
 	}
 
@@ -235,9 +252,10 @@ class Test_Post_Compile extends WP_UnitTestCase {
 		$post   = new WP_Post( (object) [ 'post_content' => $html, 'filter' => 'raw' ] );
 		$result = $this->to_text->invoke( $this->command, $post );
 
-		// 親文字＝半角スペース、ルビ＝*1。
+		// 親文字＝半角スペース、ルビ＝＊1（既定書式）。
 		$this->assertStringContainsString( '本文' . $this->body_ref( 1 ), $result );
-		// 旧形式（文字スタイルのみの注番号）は残らない。
+		// 本文はルビ形式で出るため、文字スタイルのみの平坦な注番号は残らない。
+		$this->assertStringNotContainsString( '<CharStyle:FooterNoteRef>＊1<CharStyle:>', $result );
 		$this->assertStringNotContainsString( '<CharStyle:FooterNoteRef>*1<CharStyle:>', $result );
 	}
 
@@ -251,7 +269,7 @@ class Test_Post_Compile extends WP_UnitTestCase {
 		// タグ付きテキストのヘッダが付く。
 		$this->assertStringStartsWith( '<UNICODE-MAC>', $result );
 		// 段落スタイル + 脚注参照 + 本文。
-		$this->assertStringContainsString( '<ParaStyle:FooterNote><CharStyle:FooterNoteRef>*1<CharStyle:>これは脚注', $result );
+		$this->assertStringContainsString( '<ParaStyle:FooterNote><CharStyle:FooterNoteRef>＊1<CharStyle:>これは脚注', $result );
 		// XML の痕跡は残らない。
 		$this->assertStringNotContainsString( '<?xml', $result );
 		$this->assertStringNotContainsString( '<li', $result );
@@ -267,7 +285,7 @@ class Test_Post_Compile extends WP_UnitTestCase {
 
 		// & はエスケープされず実体に戻り、URL がそのまま脚注本文になる。
 		$this->assertStringContainsString(
-			'<ParaStyle:FooterNote><CharStyle:FooterNoteRef>*1<CharStyle:>https://example.com/?a=1&b=2',
+			'<ParaStyle:FooterNote><CharStyle:FooterNoteRef>＊1<CharStyle:>https://example.com/?a=1&b=2',
 			$result
 		);
 	}
@@ -295,9 +313,9 @@ class Test_Post_Compile extends WP_UnitTestCase {
 		] );
 		$result = $this->footernote_text( $html );
 
-		$this->assertStringContainsString( '<CharStyle:FooterNoteRef>*1<CharStyle:>一', $result );
-		$this->assertStringContainsString( '<CharStyle:FooterNoteRef>*2<CharStyle:>https://example.com/x', $result );
-		$this->assertStringContainsString( '<CharStyle:FooterNoteRef>*3<CharStyle:>三', $result );
+		$this->assertStringContainsString( '<CharStyle:FooterNoteRef>＊1<CharStyle:>一', $result );
+		$this->assertStringContainsString( '<CharStyle:FooterNoteRef>＊2<CharStyle:>https://example.com/x', $result );
+		$this->assertStringContainsString( '<CharStyle:FooterNoteRef>＊3<CharStyle:>三', $result );
 	}
 
 	/**
@@ -305,5 +323,39 @@ class Test_Post_Compile extends WP_UnitTestCase {
 	 */
 	public function test_no_footernote_returns_empty() {
 		$this->assertSame( '', $this->footernote_text( '脚注もリンクも無い本文。' ) );
+	}
+
+	/**
+	 * 既定の注番号書式が全角アスタリスクであること（縦書き対応）。
+	 */
+	public function test_default_note_format_is_fullwidth_asterisk() {
+		$body = $this->convert( '本文<small class="footernote-ref">脚注</small>。' );
+		$this->assertStringContainsString( '<cRubyString:＊1>', $body );
+		// 半角アスタリスクは使わない。
+		$this->assertStringNotContainsString( '<cRubyString:*1>', $body );
+	}
+
+	/**
+	 * --note-format 相当の書式指定が本文・脚注リストの双方に反映されること。
+	 */
+	public function test_note_format_option_applies_to_body_and_list() {
+		$html = '本文<small class="footernote-ref">脚注</small>。';
+
+		// 本文側: ルビが ［1］ になる。
+		$body = $this->convert_with_format( $html, '［%d］' );
+		$this->assertStringContainsString( $this->body_ref( 1, '［%d］' ), $body );
+		$this->assertStringContainsString( '<cRubyString:［1］>', $body );
+
+		// 脚注リスト側: 同じ書式で番号が出る。
+		$notes = $this->footernote_text( $html, '［%d］' );
+		$this->assertStringContainsString( '<CharStyle:FooterNoteRef>［1］<CharStyle:>脚注', $notes );
+	}
+
+	/**
+	 * ダガー等の任意記号も書式指定できること。
+	 */
+	public function test_note_format_supports_arbitrary_symbol() {
+		$body = $this->convert_with_format( '本文<small class="footernote-ref">脚注</small>。', '†%d' );
+		$this->assertStringContainsString( '<cRubyString:†1>', $body );
 	}
 }


### PR DESCRIPTION
## 概要

`wp hampost compile ... --format=text` の**本文中の注参照マーカー**を、InDesignで組版上の注番号にできる形式へ変更し、さらに注番号の見た目を `--note-format` で切り替えられるようにします。

## 背景

- 従来 `<CharStyle:FooterNoteRef>*12<CharStyle:>`（文字スタイルのみ）では InDesign で注番号（組版）にできなかった。
- 注番号の記号は作品によって異なる（全角アスタリスク＊、全角角カッコ［］、ダガー†など）。縦書きでは半角記号が正しく反応しない。

## 変更内容

### 1. 注番号をルビ形式で出力
本文の注参照を「半角スペースを親文字（`FooterNoteRef` で圧縮）にし、注番号をそのルビとして付ける」形式へ:

```
<cMojiRuby:0><cRuby:1><cRubyString:＊12><CharStyle:FooterNoteRef> <CharStyle:><cMojiRuby:><cRuby:><cRubyString:>
```

- 親文字＝半角スペース（`FooterNoteRef` で縦圧縮）、ルビ＝注番号
- 前後の文脈に依存しないため、リンク由来・通常脚注のどちらも同一形式で確実に出力
- ルビ構文は既存の `<ruby>` 変換と同じもの

### 2. 注番号の書式を `--note-format` で指定
- `--note-format=<書式>` で sprintf 書式を指定（`%d` が番号に置換）
- **既定は `＊%d`（全角アスタリスク）** — 縦書きで反応する形式
- 例: `--note-format='［%d］'`、`--note-format='†%d'`
- `%d` を含まない書式はエラーで弾く
- 本文のルビと脚注リスト（`post-{ID}-footernote.txt`）の**双方に同じ書式**を適用（番号の見た目が一致）

## 検証
- PHPUnit 全17件（本機能）通過。ルビ形式・既定の全角＊・書式指定（［］/ダガー）が本文＆リスト双方に反映されることを検証
- `php -l` / `phpcs` クリーン（残る指摘は既存コードのみ）

## ⚠️ 導入時の確認事項
- InDesign側で `FooterNoteRef` 文字スタイルに「半角スペースを縦圧縮」する設定が前提。
- 実データでの取り込み確認をお願いします。書式が作品ごとに違う場合は `--note-format` で切り替えてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)