### PR TITLE
CI: master→release PR ではテストを実行しない

### DIFF
--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - master
-      - release
 
 jobs:
   test:


### PR DESCRIPTION
## 概要
`wordpress.yml`（Hametuha CI Test）の `pull_request` トリガーから `release` を削除します。

## 背景
- `release` は元々「master→release PR に `Status Check` を出して release ルールセットの必須チェックを満たす」ために入っていた。
- しかし release ルールセットから `Status Check` の必須要件を外したため、この目的は不要になった。
- また GITHUB_TOKEN 製の自動PRでは初期発火せず、master への実push時だけ synchronize で走るという不安定な挙動になっていた。

## 変更後の挙動
| トリガー | テスト |
|---|---|
| feature → master PR | 走る（維持） |
| master → release PR | 走らない（意図通り） |

master 向けPRで検証済みのコードがそのまま release へ流れる運用のため、release PR での再テストは冗長。release ルールセットもチェックを要求しないためブロックもされない。

## 影響確認
- `deploy-to-production`（release publish トリガー）、`auto-create-release-draft`（push:release トリガー）は独立しており影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)