### PR TITLE
Snyk: wp-cron.php DoS (CVE-2023-22622) を ignore 登録

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,14 @@
+# Snyk (https://snyk.io) policy file
+version: v1.5.0
+ignore:
+  # CVE-2023-22622: wp-cron.php を悪用した DoS。全バージョン該当・修正版なし（won't-fix）。
+  # 本番は DISABLE_WP_CRON 済み＋crontab運用で、nginx/edge で /wp-cron.php への
+  # 直接アクセスをブロックして緩和する。インフラ側対応: hametuha/hametuha-infra#19
+  SNYK-PHP-JOHNPBLOCHWORDPRESSCORE-3225115:
+    - '*':
+        reason: >-
+          CVE-2023-22622 (wp-cron.php DoS). No fixed version exists; mitigated at
+          the server/edge layer by blocking direct access to wp-cron.php.
+          Tracking: hametuha/hametuha-infra#19
+        expires: 2027-07-23T00:00:00.000Z
+patch: {}


### PR DESCRIPTION
## 概要
Snyk が継続検出している **CVE-2023-22622（wp-cron.php DoS, Medium）** を `.snyk` ポリシーで ignore する。

## 理由
- 全バージョン該当・**修正版なし（won't-fix）** のため、WordPress コアのバージョン更新では解消しない。
- 本質的な対策は **サーバー/エッジ層で `wp-cron.php` への直接アクセスをブロック**すること（アプリ側では対処不能）。
- 本番は `DISABLE_WP_CRON` 済み＋crontab運用。nginx/CloudFront での直接アクセス遮断をインフラ側で対応予定。

## 関連
- インフラ側トラッキング: **hametuha/hametuha-infra#19**
- Snyk: https://security.snyk.io/vuln/SNYK-PHP-JOHNPBLOCHWORDPRESSCORE-3225115

## 補足
- `expires: 2027-07-23` を設定。won't-fix だが1年後に再レビューして緩和状況（インフラ対応の完了）を確認する意図。
- `Check Vulnerability` は `continue-on-error: true` で元々非ブロックだが、明示的に ignore することで今後 High 等が出た際に埋もれないようにする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)