### PR TITLE
CI: Snyk脆弱性チェックを feature→master PR に移動

### DIFF
--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -34,17 +34,3 @@ jobs:
             *このPRは master ブランチへの push をトリガーにして自動生成されています。*
           pr_label: "deploy"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  vulnerability:
-    name: Check Vulnerability
-    runs-on: ubuntu-latest
-    continue-on-error: true  # Snykの結果は情報提供のみとし、CIをブロックしない（推移的依存の未修正Lowなどを許容するため）
-    steps:
-      - uses: actions/checkout@main
-
-      - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/php@master
-        with:
-          args: --all-projects
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN_FUMIKITO }}

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -57,6 +57,22 @@ jobs:
         run: npm run package
         working-directory: themes/hametuha
 
+  vulnerability:
+    name: Check Vulnerability
+    runs-on: ubuntu-latest
+    # TODO: 脆弱性ゼロ（オールグリーン）を達成したら status-check の needs に追加し、
+    #       continue-on-error を外してマージゲート化する。
+    continue-on-error: true  # 当面は情報提供のみとし、CIをブロックしない
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/php@master
+        with:
+          args: --all-projects
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN_FUMIKITO }}
+
   status-check:
     name: Status Check
     needs: [asset, test]

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+# GITHUB_TOKEN の権限を最小限に制限（CodeQL: actions/missing-workflow-permissions）
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
## 概要
Snyk の `Check Vulnerability` ジョブを `auto-pr-to-release.yml`（push:master トリガー）から `wordpress.yml`（pull_request→master トリガー）へ移設します。

## 背景 / 狙い
これまで Snyk は **master へマージされた後**にしか走らず、事前ゲートになっていなかった（feature→master PR では検出できない）。品質チェックを feature→master PR に集約する方針（#379 でテストも同様に整理済み）に合わせ、**脆弱性も master に入る前に検出**できるようにする。

## 変更後の役割分担
| トリガー | 実行内容 |
|---|---|
| feature → master PR | test / lint / asset / **Snyk**（新規） |
| master → release PR | なし（検証済みコードが流れるだけ） |

## 段階移行
- 当面は `continue-on-error: true` の**情報提供のみ**（非ブロック）。既存の Low 脆弱性（guzzle系）や運用でブロックしないため。
- 将来 **オールグリーン達成後**、`status-check` の `needs` に `vulnerability` を追加し `continue-on-error` を外して**マージゲート化**する（コードに TODO 明記）。

## 補足
- wp-cron DoS（CVE-2023-22622）は #380 の `.snyk` で ignore 済み。
- `auto-pr-to-release.yml` は PR自動作成ジョブのみになり、責務が明確化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)