### PR TITLE
hampost compile: 注番号ルビの文字スタイルをルビ外側へ移動（InDesignタグ不一致修正）

### DIFF
--- a/themes/hametuha/src/Hametuha/Commands/Post.php
+++ b/themes/hametuha/src/Hametuha/Commands/Post.php
@@ -371,11 +371,15 @@ class Post extends Command {
 		// 半角スペースを親文字（FooterNoteRef で圧縮）にし、注番号をそのルビとして付ける。
 		// こうすると前後の文脈に依存せず、リンク由来・通常脚注のどちらも同一形式で確実に出せる。
 		// 注番号の見た目（＊/［］/ダガー等）は $note_format で切り替えられる。
+		//
+		// 文字スタイル（FooterNoteRef）はルビの外側に置く。内側に入れて <CharStyle:> で解除すると、
+		// まだ閉じていないルビの文字属性まで一緒にリセットされ、InDesign 側でルビ終了タグが
+		// 「対応する開始タグなし」エラーになるため。ルビを先に閉じてから文字スタイルを解除する。
 		$note_id = 0;
 		$content = preg_replace_callback( '#<small class="footernote-ref">(.*?)</small>#u', function ( $matches ) use ( &$note_id, $note_format ) {
 			$note_id++;
 			return sprintf(
-				'<cMojiRuby:0><cRuby:1><cRubyString:%s><CharStyle:FooterNoteRef> <CharStyle:><cMojiRuby:><cRuby:><cRubyString:>',
+				'<CharStyle:FooterNoteRef><cMojiRuby:0><cRuby:1><cRubyString:%s> <cMojiRuby:><cRuby:><cRubyString:><CharStyle:>',
 				sprintf( $note_format, $note_id )
 			);
 		}, $content );

--- a/themes/hametuha/tests/Test_Post_Compile.php
+++ b/themes/hametuha/tests/Test_Post_Compile.php
@@ -206,8 +206,9 @@ class Test_Post_Compile extends WP_UnitTestCase {
 	 * @return string
 	 */
 	protected function body_ref( $n, $format = '＊%d' ) {
+		// 文字スタイルはルビの外側（ルビを閉じてから CharStyle を解除する）。
 		return sprintf(
-			'<cMojiRuby:0><cRuby:1><cRubyString:%s><CharStyle:FooterNoteRef> <CharStyle:><cMojiRuby:><cRuby:><cRubyString:>',
+			'<CharStyle:FooterNoteRef><cMojiRuby:0><cRuby:1><cRubyString:%s> <cMojiRuby:><cRuby:><cRubyString:><CharStyle:>',
 			sprintf( $format, $n )
 		);
 	}
@@ -257,6 +258,9 @@ class Test_Post_Compile extends WP_UnitTestCase {
 		// 本文はルビ形式で出るため、文字スタイルのみの平坦な注番号は残らない。
 		$this->assertStringNotContainsString( '<CharStyle:FooterNoteRef>＊1<CharStyle:>', $result );
 		$this->assertStringNotContainsString( '<CharStyle:FooterNoteRef>*1<CharStyle:>', $result );
+		// 回帰防止: ルビを閉じる前に文字スタイルを解除する並び（InDesign でルビ終了タグ
+		// 不一致エラーになる）が出ないこと。CharStyle 解除はルビ終了より後。
+		$this->assertStringNotContainsString( '<CharStyle:><cMojiRuby:>', $result );
 	}
 
 	/**


### PR DESCRIPTION
## 概要

`wp hampost compile ... --format=text` が出力する本文の注番号ルビで、InDesign 取り込み時に発生していた「文字レベル属性終了タグに対応する開始タグがない」エラーを修正します。

## 症状

InDesign 取り込み時に以下のエラー:
```
文字レベル属性終了タグ "<cMojiRuby:>" の中で、対応する文字レベル属性アプリケーションタグ "<cMojiRuby:Value>" のないものを無視します。
（cRuby / cRubyString も同様）
```

## 原因

注番号ルビの親文字（半角スペース）に付ける文字スタイル `FooterNoteRef` を**ルビの内側**に置いていた:

```
<cMojiRuby:0><cRuby:1><cRubyString:＊1><CharStyle:FooterNoteRef> <CharStyle:><cMojiRuby:><cRuby:><cRubyString:>
```

`<CharStyle:>`（文字スタイル解除）が、まだ閉じていないルビの文字属性まで一緒にリセットしてしまい、後続のルビ終了タグが「対応する開始なし」となっていた。（`<ruby>` 由来の通常ルビはこの文字スタイルが無いためエラーが出ていなかった。）

## 修正

文字スタイルを**ルビの外側**へ移動し、ルビを先に閉じてから文字スタイルを解除する:

```
<CharStyle:FooterNoteRef><cMojiRuby:0><cRuby:1><cRubyString:＊1> <cMojiRuby:><cRuby:><cRubyString:><CharStyle:>
```

親文字（半角スペース）に `FooterNoteRef` が効く点は維持。

## 検証
- PHPUnit: テーマ全体 41 tests / 127 assertions 通過（`Test_Post_Compile` 17件を含む）
- 回帰防止アサーション追加: 旧バグ形 `<CharStyle:><cMojiRuby:>` が本文に出ないことを検証
- ⚠️ 実 InDesign での取り込み確認は要お願い

🤖 Generated with [Claude Code](https://claude.com/claude-code)