### PR TITLE
fix: Percy VRT時にGA4ページビューを記録しないよう除外

### DIFF
--- a/snapshots.yml
+++ b/snapshots.yml
@@ -1,18 +1,18 @@
 - name: Homepage
-  url: https://hametuha.com/
+  url: https://hametuha.com/?vrt=percy
 - name: News
-  url: https://hametuha.com/news/
+  url: https://hametuha.com/news/?vrt=percy
 - name: News Article
-  url: https://hametuha.com/news/article/15395/
+  url: https://hametuha.com/news/article/15395/?vrt=percy
 - name: Novel
-  url: https://hametuha.com/novel/10038/
+  url: https://hametuha.com/novel/10038/?vrt=percy
 - name: Series
-  url: https://hametuha.com/series/hakobune/
+  url: https://hametuha.com/series/hakobune/?vrt=percy
 - name: Thread
-  url: https://hametuha.com/thread/
+  url: https://hametuha.com/thread/?vrt=percy
 - name: Thread Detail
-  url: https://hametuha.com/thread/%e6%9c%97%e8%aa%ad%e4%bc%9a%e3%82%92%e3%82%84%e3%82%8a%e3%81%be%e3%81%9b%e3%82%93%e3%81%8b/
+  url: https://hametuha.com/thread/%e6%9c%97%e8%aa%ad%e4%bc%9a%e3%82%92%e3%82%84%e3%82%8a%e3%81%be%e3%81%9b%e3%82%93%e3%81%8b/?vrt=percy
 - name: Help
-  url: https://hametuha.com/help/
+  url: https://hametuha.com/help/?vrt=percy
 - name: FAQ
-  url: https://hametuha.com/faq/novel-writing-basic/
+  url: https://hametuha.com/faq/novel-writing-basic/?vrt=percy

--- a/themes/hametuha/src/Hametuha/Hooks/Analytics.php
+++ b/themes/hametuha/src/Hametuha/Hooks/Analytics.php
@@ -98,14 +98,18 @@ class Analytics extends Singleton {
 		if ( 'local' === wp_get_environment_type() && ! defined( 'HAMETUHA_LOCAL_GA4' ) ) {
 			return;
 		}
+		// Skip tracking during Percy VRT capture.
+		// Percy re-renders the captured DOM on its own infrastructure (browser x width),
+		// so a client-side guard cannot stop pageviews. We must avoid outputting the tag
+		// into the snapshot at capture time. Percy visits carry ?vrt=percy (see snapshots.yml).
+		if ( isset( $_GET['vrt'] ) && 'percy' === sanitize_text_field( wp_unslash( $_GET['vrt'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
 		?>
 		<!-- Google tag (gtag.js) -->
 		<script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo esc_js( $this->ga ); ?>"></script>
 		<script>
 		(function() {
-			if ( window.__PERCY__ ) {
-				return;
-			}
 			window.dataLayer = window.dataLayer || [];
 
 			function gtag() {


### PR DESCRIPTION
## 問題

Percy VRT（`percy-vrt.yml`）の実行時に、スナップショット対象ページ（作品含む）に**GA4のページビューが記録されてしまう**。

`Analytics.php` の `window.__PERCY__` ガードは、Percyがその変数を設定しないため**常に素通り**しており、除外は機能していなかった。

## 原因（GA4実データで確定）

Percyは2フェーズで動作する:
1. **キャプチャ**（CIのローカルブラウザが本番URLを開きDOMをシリアライズ）
2. **レンダリング**（percy.ioがブラウザ×幅で再描画してスクショ取得）

`.percy.yml` の `enable-javascript: true` により②でJSが再実行され、gtagが発火する。GA4実データで `/novel/10038/` のPVが**4ブラウザ（Chrome/Edge/Firefox/Safari）完全同数**で計上されていることを確認し、発生源が②レンダリングであると特定した（人間のtrafficではこの対称性は生じない）。

`.percy.yml` の `discovery.disallowed-hostnames` は①キャプチャのアセット探索にしか効かず、②レンダリングの外向きリクエストは止められない（[Percy公式](https://www.browserstack.com/docs/percy/references/config-options)）。

## 対策

**キャプチャ時にGAタグをDOMへ出力しない** = DOMに無ければ②でも発火しない、というPercy公式推奨のアプローチ。

- `snapshots.yml`: 各URLに `?vrt=percy` を付与（`name:` は不変なので比較結果に影響なし）
- `Analytics.php`: `do_tracking_code()` 冒頭で `?vrt=percy` を検知したら早期return。機能していなかった `window.__PERCY__` ガードは撤去

## 検証

本番反映後にVRTを手動実行（`workflow_dispatch`）→ GA4で対象ページのPVをブラウザ別・日別に確認し、「4ブラウザ同数」の行が発生しなくなることで実証する（デプロイ後に実施）。

refs #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)