### PR TITLE
序文・あとがきの見出しを作品ごとに変更できるようにする

### DIFF
--- a/themes/hametuha/src/Hametuha/Commands/Post.php
+++ b/themes/hametuha/src/Hametuha/Commands/Post.php
@@ -279,11 +279,21 @@ class Post extends Command {
 		}
 		// Compile series preface and afterword.
 		if ( $series ) {
+			// キーはファイル名用のスラッグ、label は原稿に書き出す表示名。
+			// あとがきの表示名はシリーズ側で「解説」などに変更できる。
 			$extras = [
-				'preface'   => get_post_meta( $series->ID, '_preface', true ),
-				'afterword' => $series->post_content,
+				'preface'   => [
+					'label'   => 'はじめに',
+					'content' => get_post_meta( $series->ID, '_preface', true ),
+				],
+				'afterword' => [
+					'label'   => Series::get_instance()->get_afterword_title( $series->ID ),
+					'content' => $series->post_content,
+				],
 			];
-			foreach ( $extras as $label => $content ) {
+			foreach ( $extras as $slug => $extra ) {
+				$label   = $extra['label'];
+				$content = $extra['content'];
 				if ( empty( $content ) ) {
 					continue;
 				}
@@ -293,8 +303,8 @@ class Post extends Command {
 				switch ( $format ) {
 					case 'text':
 						$tagged_text = "<UNICODE-MAC>\n" . $this->to_text( $content_post, '', $note_format );
-						file_put_contents( "{$dir}/series-{$label}.txt", mb_convert_encoding( str_replace( "\n", "\r", $tagged_text ), 'UTF-16BE', 'utf-8' ) );
-						self::l( sprintf( 'series %s saved.', $label ) );
+						file_put_contents( "{$dir}/series-{$slug}.txt", mb_convert_encoding( str_replace( "\n", "\r", $tagged_text ), 'UTF-16BE', 'utf-8' ) );
+						self::l( sprintf( 'series %s (%s) saved.', $slug, $label ) );
 						break;
 					case 'plain':
 						$header = implode( "\n", [
@@ -302,8 +312,8 @@ class Post extends Command {
 							str_repeat( '-', 40 ),
 							'',
 						] );
-						file_put_contents( "{$dir}/series-{$label}-plain.txt", $header . $content );
-						self::l( sprintf( 'series %s saved.', $label ) );
+						file_put_contents( "{$dir}/series-{$slug}-plain.txt", $header . $content );
+						self::l( sprintf( 'series %s (%s) saved.', $slug, $label ) );
 						break;
 				}
 			}

--- a/themes/hametuha/src/Hametuha/Commands/Post.php
+++ b/themes/hametuha/src/Hametuha/Commands/Post.php
@@ -280,14 +280,15 @@ class Post extends Command {
 		// Compile series preface and afterword.
 		if ( $series ) {
 			// キーはファイル名用のスラッグ、label は原稿に書き出す表示名。
-			// あとがきの表示名はシリーズ側で「解説」などに変更できる。
-			$extras = [
+			// 表示名はシリーズ側で「序」「解説」などに変更できる。
+			$series_model = Series::get_instance();
+			$extras       = [
 				'preface'   => [
-					'label'   => 'はじめに',
+					'label'   => $series_model->get_preface_title( $series->ID ),
 					'content' => get_post_meta( $series->ID, '_preface', true ),
 				],
 				'afterword' => [
-					'label'   => Series::get_instance()->get_afterword_title( $series->ID ),
+					'label'   => $series_model->get_afterword_title( $series->ID ),
 					'content' => $series->post_content,
 				],
 			];

--- a/themes/hametuha/src/Hametuha/MetaBoxes/SeriesEPubMetaBox.php
+++ b/themes/hametuha/src/Hametuha/MetaBoxes/SeriesEPubMetaBox.php
@@ -21,13 +21,13 @@ class SeriesEPubMetaBox extends LeadMetaBox {
 	protected $priority = 'high';
 
 	protected $fields = [
-		'subtitle' => [
+		'subtitle'         => [
 			'class'       => Text::class,
 			'label'       => 'サブタイトル',
 			'required'    => false,
 			'description' => 'サブタイトルがあればつけてください。',
 		],
-		'excerpt'  => [
+		'excerpt'          => [
 			'class'       => TextArea::class,
 			'label'       => 'リード',
 			'required'    => true,
@@ -37,12 +37,19 @@ class SeriesEPubMetaBox extends LeadMetaBox {
 			'description' => 'リードは作品集のWebページおよび電子書籍販売ストアに一番最初に表示されます。作品を読むための非常に重要な要素なので、よく考えて入力してください。',
 			'placeholder' => 'ex. 都内有数のお嬢様学校をゾンビの群れが襲撃する！　そのときたまたま編入した「俺」は今年から共学になったこの学校唯一の男子として、全校生徒を守るべく釘バット一本で立ち向かう。21世紀を代表する新たなゾンビ文学の金字塔、ここに爆誕。',
 		],
-		'_preface' => [
+		'_preface'         => [
 			'class'       => TextArea::class,
 			'label'       => 'はじめに',
 			'required'    => false,
 			'rows'        => 10,
 			'description' => '入力した場合、本文の前に挿入されます。序文や献辞としてお使いください。HTMLを使用することができます。',
+		],
+		'_afterword_title' => [
+			'class'       => Text::class,
+			'label'       => 'あとがきのタイトル',
+			'required'    => false,
+			'placeholder' => 'あとがき',
+			'description' => 'あとがきの見出しと目次に表示される名前です。空欄の場合は「あとがき」になります。「解説」「跋」「あとがきにかえて」などに変更できます。',
 		],
 	];
 }

--- a/themes/hametuha/src/Hametuha/MetaBoxes/SeriesEPubMetaBox.php
+++ b/themes/hametuha/src/Hametuha/MetaBoxes/SeriesEPubMetaBox.php
@@ -37,9 +37,16 @@ class SeriesEPubMetaBox extends LeadMetaBox {
 			'description' => 'リードは作品集のWebページおよび電子書籍販売ストアに一番最初に表示されます。作品を読むための非常に重要な要素なので、よく考えて入力してください。',
 			'placeholder' => 'ex. 都内有数のお嬢様学校をゾンビの群れが襲撃する！　そのときたまたま編入した「俺」は今年から共学になったこの学校唯一の男子として、全校生徒を守るべく釘バット一本で立ち向かう。21世紀を代表する新たなゾンビ文学の金字塔、ここに爆誕。',
 		],
+		'_preface_title'   => [
+			'class'       => Text::class,
+			'label'       => '序文のタイトル',
+			'required'    => false,
+			'placeholder' => 'はじめに',
+			'description' => '序文の見出しと目次に表示される名前です。空欄の場合は「はじめに」になります。「序」「献辞」「まえがき」などに変更できます。',
+		],
 		'_preface'         => [
 			'class'       => TextArea::class,
-			'label'       => 'はじめに',
+			'label'       => '序文',
 			'required'    => false,
 			'rows'        => 10,
 			'description' => '入力した場合、本文の前に挿入されます。序文や献辞としてお使いください。HTMLを使用することができます。',

--- a/themes/hametuha/src/Hametuha/Model/Series.php
+++ b/themes/hametuha/src/Hametuha/Model/Series.php
@@ -17,6 +17,13 @@ use WPametu\DB\Model;
 class Series extends Model {
 
 	/**
+	 * Default title of preface.
+	 *
+	 * @var string
+	 */
+	const DEFAULT_PREFACE_TITLE = 'はじめに';
+
+	/**
 	 * Default title of afterword.
 	 *
 	 * @var string
@@ -218,6 +225,21 @@ class Series extends Model {
 	}
 
 	/**
+	 * Get preface title.
+	 *
+	 * 序文の本文は `_preface`、見出しは `_preface_title` で
+	 * 「序」「献辞」などに変更できる。
+	 * 未設定・空白のみの場合はデフォルトの「はじめに」を返す。
+	 *
+	 * @param int $post_id
+	 *
+	 * @return string
+	 */
+	public function get_preface_title( $post_id ) {
+		return $this->get_custom_title( $post_id, '_preface_title', self::DEFAULT_PREFACE_TITLE );
+	}
+
+	/**
 	 * Get afterword title.
 	 *
 	 * あとがきの本文はシリーズ投稿の post_content だが、
@@ -229,10 +251,23 @@ class Series extends Model {
 	 * @return string
 	 */
 	public function get_afterword_title( $post_id ) {
-		$title = (string) get_post_meta( $post_id, '_afterword_title', true );
+		return $this->get_custom_title( $post_id, '_afterword_title', self::DEFAULT_AFTERWORD_TITLE );
+	}
+
+	/**
+	 * Get user defined title, or fallback to the default.
+	 *
+	 * @param int    $post_id
+	 * @param string $meta_key
+	 * @param string $default
+	 *
+	 * @return string
+	 */
+	protected function get_custom_title( $post_id, $meta_key, $default ) {
+		$title = (string) get_post_meta( $post_id, $meta_key, true );
 		// trim() は全角スペースを落とさないので、前後の空白は正規表現で除去する。
 		$title = preg_replace( '/\A[\s　]+|[\s　]+\z/u', '', $title );
-		return $title ?: self::DEFAULT_AFTERWORD_TITLE;
+		return $title ?: $default;
 	}
 
 	/**

--- a/themes/hametuha/src/Hametuha/Model/Series.php
+++ b/themes/hametuha/src/Hametuha/Model/Series.php
@@ -17,6 +17,13 @@ use WPametu\DB\Model;
 class Series extends Model {
 
 	/**
+	 * Default title of afterword.
+	 *
+	 * @var string
+	 */
+	const DEFAULT_AFTERWORD_TITLE = 'あとがき';
+
+	/**
 	 * This seems a bug.
 	 *
 	 * @todo Fix this and make patch.
@@ -208,6 +215,24 @@ class Series extends Model {
 	 */
 	public function get_preface( $post_id ) {
 		return (string) get_post_meta( $post_id, '_preface', true );
+	}
+
+	/**
+	 * Get afterword title.
+	 *
+	 * あとがきの本文はシリーズ投稿の post_content だが、
+	 * 見出しは `_afterword_title` で「解説」「跋」などに変更できる。
+	 * 未設定・空白のみの場合はデフォルトの「あとがき」を返す。
+	 *
+	 * @param int $post_id
+	 *
+	 * @return string
+	 */
+	public function get_afterword_title( $post_id ) {
+		$title = (string) get_post_meta( $post_id, '_afterword_title', true );
+		// trim() は全角スペースを落とさないので、前後の空白は正規表現で除去する。
+		$title = preg_replace( '/\A[\s　]+|[\s　]+\z/u', '', $title );
+		return $title ?: self::DEFAULT_AFTERWORD_TITLE;
 	}
 
 	/**

--- a/themes/hametuha/src/Hametuha/Rest/EPub.php
+++ b/themes/hametuha/src/Hametuha/Rest/EPub.php
@@ -154,7 +154,7 @@ class EPub extends RestTemplate {
 			// Add preface if exists
 			if ( $preface = $this->series->get_preface( $series->ID ) ) {
 				$html['foreword'] = [
-					'label' => 'はじめに',
+					'label' => $this->series->get_preface_title( $series->ID ),
 					'html'  => $this->get_content( $series_id, $series, 'foreword', $direction ),
 				];
 			}
@@ -350,10 +350,16 @@ class EPub extends RestTemplate {
 				$this->title = '著者一覧';
 				break;
 			case 'foreword':
-				$this->title = 'はじめに';
+				$this->title = $this->series->get_preface_title( $post->ID );
 				if ( ! $this->series->get_preface( $post->ID ) ) {
 					throw new \Exception( '序文は設定されていません。', 403 );
 				}
+				// 見出しはユーザー入力なのでエスケープしてから縦中横を適用する。
+				$this->set_data( [
+					'preface_title' => 'rtl' === $direction
+						? $this->factory( $id )->parser->tcyiz( esc_html( $this->title ) )
+						: esc_html( $this->title ),
+				] );
 				break;
 			case 'content':
 				$this->title = get_post_meta( $post->ID, '_series_override', true ) ?: get_the_title( $post );

--- a/themes/hametuha/src/Hametuha/Rest/EPub.php
+++ b/themes/hametuha/src/Hametuha/Rest/EPub.php
@@ -168,7 +168,7 @@ class EPub extends RestTemplate {
 			// Add afterwords
 			if ( ! empty( $series->post_content ) ) {
 				$html['afterword'] = [
-					'label' => 'あとがき',
+					'label' => $this->series->get_afterword_title( $series->ID ),
 					'html'  => $this->get_content( $series_id, $series, 'afterword', $direction ),
 				];
 			}
@@ -378,10 +378,16 @@ class EPub extends RestTemplate {
 				$this->set_data( $this->factory( $id )->toc->getNavHTML( '本文' ), 'toc' );
 				break;
 			case 'afterword':
-				$this->title = 'あとがき';
+				$this->title = $this->series->get_afterword_title( $post->ID );
 				if ( empty( $post->post_content ) ) {
 					throw new \Exception( 'あとがきは設定されていません。', 403 );
 				}
+				// 見出しはユーザー入力なのでエスケープしてから縦中横を適用する。
+				$this->set_data( [
+					'afterword_title' => 'rtl' === $direction
+						? $this->factory( $id )->parser->tcyiz( esc_html( $this->title ) )
+						: esc_html( $this->title ),
+				] );
 				break;
 			case 'ads':
 				$this->title = '破滅派電子書籍近刊';

--- a/themes/hametuha/templates/epub/afterword.php
+++ b/themes/hametuha/templates/epub/afterword.php
@@ -1,11 +1,12 @@
 <?php
 /** @var WP_Post $series */
+/** @var string $afterword_title エスケープ済みの見出し。 */
 ?>
 <?php get_template_part( 'templates/epub/header' ); ?>
 
 <div class="header header--afterwords">
 	<h1 class="title">
-		あとがき
+		<?php echo $afterword_title; ?>
 	</h1>
 </div>
 

--- a/themes/hametuha/templates/epub/foreword.php
+++ b/themes/hametuha/templates/epub/foreword.php
@@ -1,11 +1,12 @@
 <?php
 /** @var WP_Post $series */
+/** @var string $preface_title エスケープ済みの見出し。 */
 ?>
 <?php get_template_part( 'templates/epub/header' ); ?>
 
 <div class="header header--preface">
 	<h1 class="title">
-		はじめに
+		<?php echo $preface_title; ?>
 	</h1>
 </div>
 

--- a/themes/hametuha/tests/Test_Series.php
+++ b/themes/hametuha/tests/Test_Series.php
@@ -122,9 +122,16 @@ class Test_Series extends WP_UnitTestCase {
 	}
 
 	/**
-	 * あとがきのタイトルが上書きできることをテスト
+	 * 序文・あとがきのタイトルが上書きできることをテスト
+	 *
+	 * @dataProvider custom_title_provider
+	 *
+	 * @param string $method   Series モデルのメソッド名。
+	 * @param string $meta_key 上書き用のメタキー。
+	 * @param string $default  未設定時のデフォルト。
+	 * @param string $custom   上書きする値。
 	 */
-	public function test_afterword_title() {
+	public function test_custom_title( $method, $meta_key, $default, $custom ) {
 		// publish に遷移させると計測フック（cookie-tasting プラグイン依存）が走るため draft で作る。
 		$series_id = $this->factory->post->create( [
 			'post_type'   => 'series',
@@ -132,19 +139,29 @@ class Test_Series extends WP_UnitTestCase {
 		] );
 
 		// 未設定ならデフォルト。
-		$this->assertSame( 'あとがき', $this->series->get_afterword_title( $series_id ) );
+		$this->assertSame( $default, $this->series->$method( $series_id ) );
 
-		// 空白のみでもデフォルト。
-		update_post_meta( $series_id, '_afterword_title', " \n　" );
-		$this->assertSame( 'あとがき', $this->series->get_afterword_title( $series_id ) );
+		// 空白のみでもデフォルト（全角スペースを含む）。
+		update_post_meta( $series_id, $meta_key, " \n　" );
+		$this->assertSame( $default, $this->series->$method( $series_id ) );
 
 		// 入力があれば上書き。
-		update_post_meta( $series_id, '_afterword_title', '解説' );
-		$this->assertSame( '解説', $this->series->get_afterword_title( $series_id ) );
+		update_post_meta( $series_id, $meta_key, $custom );
+		$this->assertSame( $custom, $this->series->$method( $series_id ) );
 
 		// 前後の空白は除去される。
-		update_post_meta( $series_id, '_afterword_title', ' あとがきにかえて ' );
-		$this->assertSame( 'あとがきにかえて', $this->series->get_afterword_title( $series_id ) );
+		update_post_meta( $series_id, $meta_key, " {$custom}　" );
+		$this->assertSame( $custom, $this->series->$method( $series_id ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function custom_title_provider() {
+		return [
+			'あとがき' => [ 'get_afterword_title', '_afterword_title', 'あとがき', '解説' ],
+			'序文'     => [ 'get_preface_title', '_preface_title', 'はじめに', '献辞' ],
+		];
 	}
 
 	/**

--- a/themes/hametuha/tests/Test_Series.php
+++ b/themes/hametuha/tests/Test_Series.php
@@ -122,6 +122,32 @@ class Test_Series extends WP_UnitTestCase {
 	}
 
 	/**
+	 * あとがきのタイトルが上書きできることをテスト
+	 */
+	public function test_afterword_title() {
+		// publish に遷移させると計測フック（cookie-tasting プラグイン依存）が走るため draft で作る。
+		$series_id = $this->factory->post->create( [
+			'post_type'   => 'series',
+			'post_status' => 'draft',
+		] );
+
+		// 未設定ならデフォルト。
+		$this->assertSame( 'あとがき', $this->series->get_afterword_title( $series_id ) );
+
+		// 空白のみでもデフォルト。
+		update_post_meta( $series_id, '_afterword_title', " \n　" );
+		$this->assertSame( 'あとがき', $this->series->get_afterword_title( $series_id ) );
+
+		// 入力があれば上書き。
+		update_post_meta( $series_id, '_afterword_title', '解説' );
+		$this->assertSame( '解説', $this->series->get_afterword_title( $series_id ) );
+
+		// 前後の空白は除去される。
+		update_post_meta( $series_id, '_afterword_title', ' あとがきにかえて ' );
+		$this->assertSame( 'あとがきにかえて', $this->series->get_afterword_title( $series_id ) );
+	}
+
+	/**
 	 * 空文字列やnullのテスト
 	 */
 	public function test_empty_values() {


### PR DESCRIPTION
## 概要

電子書籍の**序文・あとがきの見出しを作品ごとに変更できる**ようにしました。従来は「はじめに」「あとがき」がリテラルでハードコードされており、変更手段がありませんでした。

- 序文 → メタ `_preface_title`（未設定なら「はじめに」）
- あとがき → メタ `_afterword_title`（未設定なら「あとがき」）

「序」「献辞」「まえがき」「解説」「跋」「あとがきにかえて」などに変更できます。

## 変更内容

### 1. `Series` モデルにゲッターを追加

デフォルト値と前後空白の除去を1箇所に集約しました。`trim()` は全角スペースを落とさないため、空白除去は正規表現で行っています。

```php
const DEFAULT_PREFACE_TITLE   = 'はじめに';
const DEFAULT_AFTERWORD_TITLE = 'あとがき';

public function get_preface_title( $post_id );
public function get_afterword_title( $post_id );
```

### 2. 編集画面（ePub設定メタボックス）

- 「序文のタイトル」「あとがきのタイトル」を追加。プレースホルダに既定値を出すので、空欄時の挙動が入力前に分かります。
- **あわせて `_preface` のラベルを「はじめに」→「序文」に変更しました。** 見出しが可変になった以上、入力欄の名前に既定の見出し名を使うのは矛盾するためです（「はじめに」欄に入れた本文の見出しが「献辞」になる、という説明の破綻を避ける）。

画面の並びは `序文のタイトル` → `序文` → `あとがきのタイトル` →（本文エディタ直前に）`あとがき` で対称です。

### 3. 反映先

| 出力先 | 実装 |
|---|---|
| EPUB nav（目次）の項目名 | `Rest/EPub.php` |
| xhtml の `<title>` | `Rest/EPub.php` の `$this->title` |
| 紙面の `<h1>` | `templates/epub/foreword.php` / `afterword.php` |
| InDesign 書き出しのヘッダー | `Commands/Post.php` |

縦書き（rtl）では既存の本文と同様に縦中横（`tcyiz`）を適用します。見出しはユーザー入力なので `esc_html()` を通してからルビ化しています。

### 4. InDesign 書き出しのバグ修正

plain 書き出しのヘッダーが `タイトル: ある朝の毒虫（afterword）` と**配列キーの英字がそのまま露出**していました。ファイル名用のスラッグと表示名を分離し、`（解説）`／`（はじめに）` と表示されるようにしました。ファイル名は機械的な識別子なので `series-afterword.txt` のままです（配置スクリプトやファイル名依存の運用を壊さないため）。

## やらなかったこと

**シリーズページ（Web）のバッジは「あとがき付き」固定のまま**にしました。一度タイトル追従を実装しましたが、`あとがきにかえて――ぼくと母の45年付き（約44文字）` のように長いタイトルで体裁が壊れるため取り消しています。

あの `<ol>` は「完結済み / N作品収録 / N文字 / あとがき付き」という**機能チェックリスト**で、各項目は1行のカテゴリ情報です。固有のタイトルは長さが予測できず、押し込む場所ではありません。Web に実タイトルを出すなら置き場所は**収録作一覧の末尾**（1項目1行なので長いタイトルが収まり、ePub の目次と構造も一致する）ですが、あとがき本文は Web 非公開でリンク先がないため、必要になってからにします。

## 検証

- `composer test` 43件 OK（`Test_Series` を `dataProvider` 化し、序文・あとがきを未設定／全角スペースのみ／上書き／前後空白除去の4ケースで検証）
- `phpcs` 新規行 clean
- **実 ePub を生成して確認**: nav に `<a href="foreword.xhtml">献辞</a>`、landmarks に `epub:type="afterword">解説`、`foreword.xhtml`／`afterword.xhtml` の h1 と `<title>` も反映。縦書きなので数字には `<span class="tcy">` が付くことも確認
- **プレビュー**（`epub/preview/foreword|afterword/{id}`）を ltr / rtl 両方で確認
- **InDesign 書き出し**を `--format=plain` / `--format=text` 両方で実行し、ヘッダーが日本語表示名・ファイル名がスラッグ維持であることを確認
- **管理画面**は実ログイン（Playwright）でフィールドの描画と保存往復を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
