### PR TITLE
子投稿を持たない単巻書籍に対応する

### DIFF
--- a/themes/hametuha/functions/meta.php
+++ b/themes/hametuha/functions/meta.php
@@ -30,13 +30,17 @@ add_filter( 'wp_title', function ( $original_title, $sep, $seplocation ) {
 		);
 	} elseif ( is_singular( 'series' ) ) {
 		// 連載
+		$is_standalone = \Hametuha\Model\Series::get_instance()->is_standalone( get_queried_object_id() );
 		return sprintf(
-			'%s『%s』（%s, %d年-, %s）',
+			// 単巻書籍は連載期間を持たないので、開始年を示すハイフンをつけない。
+			$is_standalone ? '%s『%s』（%s, %d年, %s）' : '%s『%s』（%s, %d年-, %s）',
 			hametuha_author_name( get_queried_object() ),
 			get_the_title( get_queried_object() ),
 			get_bloginfo( 'name' ),
 			mysql2date( 'Y', get_queried_object()->post_date ),
-			\Hametuha\Model\Series::get_instance()->is_finished( get_queried_object_id() ) ? '完結' : '連載中'
+			$is_standalone
+				? '刊行済み'
+				: ( \Hametuha\Model\Series::get_instance()->is_finished( get_queried_object_id() ) ? '完結' : '連載中' )
 		);
 	} elseif ( is_singular( 'news' ) ) {
 		// ニュース

--- a/themes/hametuha/functions/post_type-series.php
+++ b/themes/hametuha/functions/post_type-series.php
@@ -37,6 +37,42 @@ function is_series_finished( $post = null ) {
 }
 
 /**
+ * 単巻書籍（子投稿を持たない電子書籍）か
+ *
+ * @param null|int|WP_Post $post
+ *
+ * @return bool
+ */
+function hametuha_is_standalone_book( $post = null ) {
+	$post = get_post( $post );
+	if ( ! $post ) {
+		return false;
+	}
+	$series_id = 'series' === $post->post_type ? $post->ID : $post->post_parent;
+	if ( ! $series_id ) {
+		return false;
+	}
+
+	return Series::get_instance()->is_standalone( $series_id );
+}
+
+/**
+ * 単巻書籍の目次を取得する
+ *
+ * @param null|int|WP_Post $post
+ *
+ * @return string
+ */
+function hametuha_get_book_toc( $post = null ) {
+	$post = get_post( $post );
+	if ( ! $post || 'series' !== $post->post_type ) {
+		return '';
+	}
+
+	return Series::get_instance()->get_toc( $post->ID );
+}
+
+/**
  * Convert post query arguments.
  *
  * @param array $args

--- a/themes/hametuha/functions/post_type-series.php
+++ b/themes/hametuha/functions/post_type-series.php
@@ -57,22 +57,6 @@ function hametuha_is_standalone_book( $post = null ) {
 }
 
 /**
- * 単巻書籍の目次を取得する
- *
- * @param null|int|WP_Post $post
- *
- * @return string
- */
-function hametuha_get_book_toc( $post = null ) {
-	$post = get_post( $post );
-	if ( ! $post || 'series' !== $post->post_type ) {
-		return '';
-	}
-
-	return Series::get_instance()->get_toc( $post->ID );
-}
-
-/**
  * Convert post query arguments.
  *
  * @param array $args

--- a/themes/hametuha/hooks/series.php
+++ b/themes/hametuha/hooks/series.php
@@ -181,6 +181,9 @@ add_action( 'pre_get_posts', function ( WP_Query &$wp_query ) {
 
 /**
  * 子作品が1つもない場合はシリーズとして公開できない
+ *
+ * ただし単巻書籍（破滅派の外で制作し、本文を入稿していない書籍）は
+ * 子投稿を持たないのが正常なので除外しない。
  */
 add_filter( 'posts_join', function ( $join, WP_Query $wp_query ) {
 	if ( ! $wp_query->is_main_query() || is_admin() ) {
@@ -195,14 +198,19 @@ add_filter( 'posts_join', function ( $join, WP_Query $wp_query ) {
 	}
 
 	global $wpdb;
-	// 少なくとも1つは公開済みの子投稿が紐づいている連載のみを表示
+	// 公開済みの子投稿が1つ以上ある連載、または単巻書籍のみを表示
 	$join .= " INNER JOIN (
-		SELECT DISTINCT post_parent
+		SELECT DISTINCT post_parent AS series_id
 		FROM {$wpdb->posts}
 		WHERE post_parent > 0
 		AND post_status = 'publish'
 		AND post_type = 'post'
-	) AS series_children ON {$wpdb->posts}.ID = series_children.post_parent";
+		UNION
+		SELECT DISTINCT post_id AS series_id
+		FROM {$wpdb->postmeta}
+		WHERE meta_key = '_standalone_book'
+		AND meta_value = '1'
+	) AS series_children ON {$wpdb->posts}.ID = series_children.series_id";
 
 	return $join;
 }, 10, 2 );

--- a/themes/hametuha/parts/loop-series.php
+++ b/themes/hametuha/parts/loop-series.php
@@ -10,6 +10,8 @@ $class   = [ 'loop-series', 'shadow-sm' ];
 if ( $has_kdp ) {
 	$class[] = 'has-kdp';
 }
+// 責任者の肩書きは作品集ごとに違う（著・編集・監修・編著）。単体ページと同じものを使う。
+$owner_label = \Hametuha\Model\Collaborators::get_instance()->owner_label( get_the_ID() );
 ?>
 <li <?php post_class( implode( ' ', $class ) ); ?>>
 	<a class="loop-series__link" href="<?php the_permalink(); ?>">
@@ -38,7 +40,7 @@ if ( $has_kdp ) {
 			<ul class="loop-series__metas">
 				<li class="loop-series__meta loop-series__meta--author">
 					<?php echo get_avatar( get_the_author_meta( 'ID' ), 40 ); ?>
-					<?php the_author(); ?> 編
+					<?php the_author(); ?> <?php echo esc_html( $owner_label ); ?>
 				</li>
 				<?php if ( hametuha_is_standalone_book() ) : ?>
 					<?php // 単巻書籍は子投稿を持たないので、連載期間・作品数・文字数はいずれも算出できない。 ?>

--- a/themes/hametuha/parts/loop-series.php
+++ b/themes/hametuha/parts/loop-series.php
@@ -40,21 +40,31 @@ if ( $has_kdp ) {
 					<?php echo get_avatar( get_the_author_meta( 'ID' ), 40 ); ?>
 					<?php the_author(); ?> 編
 				</li>
-				<li class="loop-series__meta loop-series__meta--date">
-					<i class="icon-calendar2"></i> <?php the_series_range(); ?>
-				</li>
-				<li class="loop-series__meta loop-series__meta--volume d-flex justify-content-between align-center">
-					<span>
-						<i class="icon-books"></i>
-						<?php echo number_format_i18n( get_post_children_count() ); ?>作
-						（<?php the_post_length( '全', '文字', '文字数不明' ); ?>）
-					</span>
-					<?php if ( is_series_finished() ) : ?>
-						<span class="badge rounded-pill text-bg-primary">完結</span>
-					<?php else : ?>
-						<span class="badge rounded-pill text-bg-secondary">連載中</span>
-					<?php endif; ?>
-				</li>
+				<?php if ( hametuha_is_standalone_book() ) : ?>
+					<?php // 単巻書籍は子投稿を持たないので、連載期間・作品数・文字数はいずれも算出できない。 ?>
+					<li class="loop-series__meta loop-series__meta--date">
+						<i class="icon-calendar2"></i> <?php echo esc_html( get_the_date() ); ?>
+					</li>
+					<li class="loop-series__meta loop-series__meta--volume d-flex justify-content-end align-center">
+						<span class="badge rounded-pill text-bg-primary">刊行済み</span>
+					</li>
+				<?php else : ?>
+					<li class="loop-series__meta loop-series__meta--date">
+						<i class="icon-calendar2"></i> <?php the_series_range(); ?>
+					</li>
+					<li class="loop-series__meta loop-series__meta--volume d-flex justify-content-between align-center">
+						<span>
+							<i class="icon-books"></i>
+							<?php echo number_format_i18n( get_post_children_count() ); ?>作
+							（<?php the_post_length( '全', '文字', '文字数不明' ); ?>）
+						</span>
+						<?php if ( is_series_finished() ) : ?>
+							<span class="badge rounded-pill text-bg-primary">完結</span>
+						<?php else : ?>
+							<span class="badge rounded-pill text-bg-secondary">連載中</span>
+						<?php endif; ?>
+					</li>
+				<?php endif; ?>
 			</ul>
 
 

--- a/themes/hametuha/parts/series-children.php
+++ b/themes/hametuha/parts/series-children.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * 連載・作品集の収録作一覧
+ *
+ * @feature-group series
+ * @var array $args {
+ *     @type WP_Query $query 子投稿のクエリ。
+ * }
+ */
+
+$query = $args['query'] ?? null;
+if ( ! $query instanceof WP_Query ) {
+	return;
+}
+?>
+<div class="series__row series__row--children" id="series-children">
+
+	<div class="container series__inner">
+
+		<div class="row">
+			<div class="col-12 col-sm-4">
+				<h2 class="series__title--list">
+					<small class="series__title--caption">Works</small>
+					収録作一覧
+				</h2>
+			</div>
+
+			<div class="col-12 col-sm-8">
+				<?php if ( $query->have_posts() ) : ?>
+					<ol class="series__list">
+						<?php
+						$counter = 0;
+						while ( $query->have_posts() ) {
+							++$counter;
+							$query->the_post();
+							hameplate( 'parts/loop-series', get_post_type(), [
+								'counter' => $counter,
+							] );
+						}
+						wp_reset_postdata();
+						?>
+					</ol>
+
+				<?php else : ?>
+
+					<div class="alert alert-warning">
+						<p>まだ作品が登録されていません。<a class="alert-link" href="#series-notification">破滅派をフォロー</a>して、作者の活躍に期待してください。
+						</p>
+					</div>
+
+					<?php
+				endif;
+				wp_reset_postdata();
+				?>
+			</div>
+		</div>
+
+
+	</div>
+	<!-- //.container -->
+
+</div>
+<!-- series_row--children -->

--- a/themes/hametuha/parts/series-description.php
+++ b/themes/hametuha/parts/series-description.php
@@ -1,36 +1,36 @@
 <?php
 /**
- * 単巻書籍の目次
+ * 単巻書籍の内容紹介
  *
  * 本文が破滅派にないため収録作一覧を組み立てられない。書き手が入力した
  * 自由記述の HTML をそのまま表示する。空欄ならセクションごと出さない。
  *
  * @feature-group series
  * @var array $args {
- *     @type string $toc 目次のHTML。
+ *     @type string $description 内容紹介のHTML。
  * }
  */
 
-$toc = $args['toc'] ?? '';
-if ( ! $toc ) {
+$description = $args['description'] ?? '';
+if ( ! $description ) {
 	return;
 }
 ?>
-<div class="series__row series__row--children series__row--toc" id="series-children">
+<div class="series__row series__row--children series__row--description" id="series-children">
 
 	<div class="container series__inner">
 
 		<div class="row">
 			<div class="col-12 col-sm-4">
 				<h2 class="series__title--list">
-					<small class="series__title--caption">Contents</small>
-					目次
+					<small class="series__title--caption">About this Book</small>
+					内容紹介
 				</h2>
 			</div>
 
 			<div class="col-12 col-sm-8">
-				<div class="series__toc">
-					<?php echo wp_kses_post( $toc ); ?>
+				<div class="series__description">
+					<?php echo wp_kses_post( $description ); ?>
 				</div>
 			</div>
 		</div>
@@ -39,4 +39,4 @@ if ( ! $toc ) {
 	<!-- //.container -->
 
 </div>
-<!-- //.series__row--toc -->
+<!-- //.series__row--description -->

--- a/themes/hametuha/parts/series-description.php
+++ b/themes/hametuha/parts/series-description.php
@@ -30,7 +30,12 @@ if ( ! $description ) {
 
 			<div class="col-12 col-sm-8">
 				<div class="series__description">
-					<?php echo wp_kses_post( $description ); ?>
+					<?php
+					// 保存時は素通しなので、出力時に必ず kses を通す。将来この行に変換が
+					// 挟まっても守られるよう、サニタイザを最後に置く。
+					// wpautop はブロック要素を包まないので、HTMLで書いた場合はそのまま残る。
+					echo wp_kses_post( wpautop( $description ) );
+					?>
 				</div>
 			</div>
 		</div>

--- a/themes/hametuha/parts/series-toc.php
+++ b/themes/hametuha/parts/series-toc.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * 単巻書籍の目次
+ *
+ * 本文が破滅派にないため収録作一覧を組み立てられない。書き手が入力した
+ * 自由記述の HTML をそのまま表示する。空欄ならセクションごと出さない。
+ *
+ * @feature-group series
+ * @var array $args {
+ *     @type string $toc 目次のHTML。
+ * }
+ */
+
+$toc = $args['toc'] ?? '';
+if ( ! $toc ) {
+	return;
+}
+?>
+<div class="series__row series__row--children series__row--toc" id="series-children">
+
+	<div class="container series__inner">
+
+		<div class="row">
+			<div class="col-12 col-sm-4">
+				<h2 class="series__title--list">
+					<small class="series__title--caption">Contents</small>
+					目次
+				</h2>
+			</div>
+
+			<div class="col-12 col-sm-8">
+				<div class="series__toc">
+					<?php echo wp_kses_post( $toc ); ?>
+				</div>
+			</div>
+		</div>
+
+	</div>
+	<!-- //.container -->
+
+</div>
+<!-- //.series__row--toc -->

--- a/themes/hametuha/single-series.php
+++ b/themes/hametuha/single-series.php
@@ -20,6 +20,9 @@ get_header( 'breadcrumb' );
 	$query         = \Hametuha\Model\Series::get_series_posts( get_the_ID(), 'publish', true );
 	$all_reviews   = $series->get_reviews( get_the_ID(), true, 1, 12 );
 	$ratings       = [];
+	// 単巻書籍は本文を破滅派に持たないので、収録作一覧のかわりに目次を出す。
+	$is_standalone = $series->is_standalone( get_the_ID() );
+	$toc           = $is_standalone ? $series->get_toc( get_the_ID() ) : '';
 	// Calc rating
 	if ( $query->have_posts() ) {
 		foreach ( $query->posts as $p ) {
@@ -112,9 +115,15 @@ get_header( 'breadcrumb' );
 endswitch;
 						?>
 						<span class="series__link--divider"></span>
-						<a href="#series-children" class="btn btn-trans page-anker">
-							<i class="icon-books"></i> <?php esc_html_e( '収録作一覧', 'hametuah' ); ?>
-						</a>
+						<?php if ( ! $is_standalone ) : ?>
+							<a href="#series-children" class="btn btn-trans page-anker">
+								<i class="icon-books"></i> <?php esc_html_e( '収録作一覧', 'hametuah' ); ?>
+							</a>
+						<?php elseif ( $toc ) : ?>
+							<a href="#series-children" class="btn btn-trans page-anker">
+								<i class="icon-books"></i> <?php esc_html_e( '目次', 'hametuha' ); ?>
+							</a>
+						<?php endif; ?>
 						<a href="#series-testimonials" class="btn btn-trans page-anker">
 							<i class="icon-star"></i> <?php esc_html_e( 'レビュー', 'hametuha' ); ?>
 						</a>
@@ -139,35 +148,42 @@ endswitch;
 					</p>
 				<?php endif; ?>
 				<ol class="series__status">
-					<li>
-						<?php
-						$range = $series->get_series_range( get_the_ID() );
-						if ( $series->is_finished( get_the_ID() ) ) :
-							?>
-							<i class="icon-checkmark3 ok"></i> 完結済み
-							（
-							<?php echo mysql2date( get_option( 'date_format' ), $range->start_date ); ?>
-							〜
-							<?php echo mysql2date( get_option( 'date_format' ), $range->last_date ); ?>
-							）
-						<?php else : ?>
-							<i class="icon-info2 ng"></i> 連載中
-							<small>
-								（最終更新： <?php echo mysql2date( get_option( 'date_format' ), $range->last_date ); ?>
+					<?php if ( $is_standalone ) : ?>
+						<?php // 単巻書籍は子投稿を持たないので、連載期間・作品数・文字数はいずれも算出できない。 ?>
+						<li>
+							<i class="icon-checkmark3 ok"></i> 刊行済み
+						</li>
+					<?php else : ?>
+						<li>
+							<?php
+							$range = $series->get_series_range( get_the_ID() );
+							if ( $series->is_finished( get_the_ID() ) ) :
+								?>
+								<i class="icon-checkmark3 ok"></i> 完結済み
+								（
+								<?php echo mysql2date( get_option( 'date_format' ), $range->start_date ); ?>
+								〜
+								<?php echo mysql2date( get_option( 'date_format' ), $range->last_date ); ?>
 								）
-							</small>
-						<?php endif; ?>
-					</li>
-					<li>
-						<i class="icon-books ok"></i> <?php echo number_format( $query->post_count ); ?> 作品収録
-					</li>
-					<li>
-						<i class="icon-reading ok"></i>
-						<?php
-							$length = get_post_length();
-							printf( '%1$s文字（400字詰原稿用紙%2$s枚）', number_format_i18n( $length ), number_format_i18n( ceil( $length / 400 ) ) );
-						?>
-					</li>
+							<?php else : ?>
+								<i class="icon-info2 ng"></i> 連載中
+								<small>
+									（最終更新： <?php echo mysql2date( get_option( 'date_format' ), $range->last_date ); ?>
+									）
+								</small>
+							<?php endif; ?>
+						</li>
+						<li>
+							<i class="icon-books ok"></i> <?php echo number_format( $query->post_count ); ?> 作品収録
+						</li>
+						<li>
+							<i class="icon-reading ok"></i>
+							<?php
+								$length = get_post_length();
+								printf( '%1$s文字（400字詰原稿用紙%2$s枚）', number_format_i18n( $length ), number_format_i18n( ceil( $length / 400 ) ) );
+							?>
+						</li>
+					<?php endif; ?>
 					<?php
 					$afterwords = trim( $post->post_content );
 					if ( ! empty( $afterwords ) ) :
@@ -240,54 +256,13 @@ endswitch;
 
 
 	<!-- //.series__row--author -->
-	<div class="series__row series__row--children" id="series-children">
-
-		<div class="container series__inner">
-
-			<div class="row">
-				<div class="col-12 col-sm-4">
-					<h2 class="series__title--list">
-						<small class="series__title--caption">Works</small>
-						収録作一覧
-					</h2>
-				</div>
-
-				<div class="col-12 col-sm-8">
-					<?php if ( $query->have_posts() ) : ?>
-						<ol class="series__list">
-							<?php
-							$counter = 0;
-							while ( $query->have_posts() ) {
-								++$counter;
-								$query->the_post();
-								hameplate( 'parts/loop-series', get_post_type(), [
-									'counter' => $counter,
-								] );
-							}
-							wp_reset_postdata();
-							?>
-						</ol>
-
-					<?php else : ?>
-
-						<div class="alert alert-warning">
-							<p>まだ作品が登録されていません。<a class="alert-link" href="#series-notification">破滅派をフォロー</a>して、作者の活躍に期待してください。
-							</p>
-						</div>
-
-						<?php
-					endif;
-					wp_reset_postdata();
-					?>
-				</div>
-			</div>
-
-
-		</div>
-		<!-- //.container -->
-
-	</div>
-	<!-- series_row--children -->
+	<?php
+	if ( $is_standalone ) {
+		hameplate( 'parts/series-toc', '', [ 'toc' => $toc ] );
+	} else {
+		hameplate( 'parts/series-children', '', [ 'query' => $query ] );
+	}
+	?>
 
 
 	<div class="series__row series__row--testimonials" id="series-testimonials">

--- a/themes/hametuha/single-series.php
+++ b/themes/hametuha/single-series.php
@@ -20,9 +20,9 @@ get_header( 'breadcrumb' );
 	$query         = \Hametuha\Model\Series::get_series_posts( get_the_ID(), 'publish', true );
 	$all_reviews   = $series->get_reviews( get_the_ID(), true, 1, 12 );
 	$ratings       = [];
-	// 単巻書籍は本文を破滅派に持たないので、収録作一覧のかわりに目次を出す。
-	$is_standalone = $series->is_standalone( get_the_ID() );
-	$toc           = $is_standalone ? $series->get_toc( get_the_ID() ) : '';
+	// 単巻書籍は本文を破滅派に持たないので、収録作一覧のかわりに内容紹介を出す。
+	$is_standalone    = $series->is_standalone( get_the_ID() );
+	$book_description = $is_standalone ? $series->get_book_description( get_the_ID() ) : '';
 	// Calc rating
 	if ( $query->have_posts() ) {
 		foreach ( $query->posts as $p ) {
@@ -119,9 +119,9 @@ endswitch;
 							<a href="#series-children" class="btn btn-trans page-anker">
 								<i class="icon-books"></i> <?php esc_html_e( '収録作一覧', 'hametuah' ); ?>
 							</a>
-						<?php elseif ( $toc ) : ?>
+						<?php elseif ( $book_description ) : ?>
 							<a href="#series-children" class="btn btn-trans page-anker">
-								<i class="icon-books"></i> <?php esc_html_e( '目次', 'hametuha' ); ?>
+								<i class="icon-books"></i> <?php esc_html_e( '内容紹介', 'hametuha' ); ?>
 							</a>
 						<?php endif; ?>
 						<a href="#series-testimonials" class="btn btn-trans page-anker">
@@ -258,7 +258,7 @@ endswitch;
 	<!-- //.series__row--author -->
 	<?php
 	if ( $is_standalone ) {
-		hameplate( 'parts/series-toc', '', [ 'toc' => $toc ] );
+		hameplate( 'parts/series-description', '', [ 'description' => $book_description ] );
 	} else {
 		hameplate( 'parts/series-children', '', [ 'query' => $query ] );
 	}

--- a/themes/hametuha/src/Hametuha/MetaBoxes/SeriesFormatMetaBox.php
+++ b/themes/hametuha/src/Hametuha/MetaBoxes/SeriesFormatMetaBox.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Hametuha\MetaBoxes;
+
+
+use WPametu\UI\Admin\EditMetaBox;
+use WPametu\UI\Field\Radio;
+use WPametu\UI\Field\TextArea;
+
+/**
+ * 書籍の形態を指定するメタボックス
+ *
+ * 破滅派の外で制作した書籍をあとから電子化する場合、本文を入稿しないため
+ * 子投稿が存在しない。ePubの設定ではなくWeb表示の話なので、ePub系の
+ * メタボックスとは分けている。
+ *
+ * @package Hametuha\MetaBoxes
+ */
+class SeriesFormatMetaBox extends EditMetaBox {
+
+	protected $post_types = [ 'series' ];
+
+	protected $name = 'hametuha_series_format';
+
+	protected $label = '書籍の形態';
+
+	protected $context = 'advanced';
+
+	protected $priority = 'high';
+
+	protected $fields = [
+		'_standalone_book' => [
+			'class'       => Radio::class,
+			'label'       => '形態',
+			'options'     => [
+				0 => '連載・作品集（破滅派に本文を入稿する）',
+				1 => '単巻書籍（破滅派の外で制作し、本文を入稿しない）',
+			],
+			'default'     => 0,
+			'description' => '単巻書籍にすると、収録作一覧のかわりに下の目次が表示され、作品数・文字数・連載期間は表示されなくなります。売上報告や執筆者一覧はどちらでも同じように機能します。',
+		],
+		'_book_toc'        => [
+			'class'       => TextArea::class,
+			'label'       => '目次',
+			'required'    => false,
+			'rows'        => 10,
+			'description' => 'HTMLが使えます。<code>&lt;ol&gt;</code> や <code>&lt;ul&gt;</code> で目次を書いてください。空欄の場合、目次は表示されません。単巻書籍のときだけ使われます。',
+		],
+	];
+}

--- a/themes/hametuha/src/Hametuha/MetaBoxes/SeriesFormatMetaBox.php
+++ b/themes/hametuha/src/Hametuha/MetaBoxes/SeriesFormatMetaBox.php
@@ -29,7 +29,7 @@ class SeriesFormatMetaBox extends EditMetaBox {
 	protected $priority = 'high';
 
 	protected $fields = [
-		'_standalone_book' => [
+		'_standalone_book'  => [
 			'class'       => Radio::class,
 			'label'       => '形態',
 			'options'     => [
@@ -37,14 +37,14 @@ class SeriesFormatMetaBox extends EditMetaBox {
 				1 => '単巻書籍（破滅派の外で制作し、本文を入稿しない）',
 			],
 			'default'     => 0,
-			'description' => '単巻書籍にすると、収録作一覧のかわりに下の目次が表示され、作品数・文字数・連載期間は表示されなくなります。売上報告や執筆者一覧はどちらでも同じように機能します。',
+			'description' => '単巻書籍にすると、収録作一覧のかわりに下の内容紹介が表示され、作品数・文字数・連載期間は表示されなくなります。売上報告や執筆者一覧はどちらでも同じように機能します。',
 		],
-		'_book_toc'        => [
+		'_book_description' => [
 			'class'       => TextArea::class,
-			'label'       => '目次',
+			'label'       => '内容紹介',
 			'required'    => false,
 			'rows'        => 10,
-			'description' => 'HTMLが使えます。<code>&lt;ol&gt;</code> や <code>&lt;ul&gt;</code> で目次を書いてください。空欄の場合、目次は表示されません。単巻書籍のときだけ使われます。',
+			'description' => 'HTMLが使えます。目次・装丁・初出など、本の中身が伝わることを自由に書いてください。空欄の場合、内容紹介は表示されません。単巻書籍のときだけ使われます。',
 		],
 	];
 }

--- a/themes/hametuha/src/Hametuha/Model/Collaborators.php
+++ b/themes/hametuha/src/Hametuha/Model/Collaborators.php
@@ -72,7 +72,9 @@ class Collaborators extends Singleton {
 	 * @return string
 	 */
 	public function owner_label( $series_id ) {
-		return $this->owner_types[ $this->owner_type( $series_id ) ];
+		$type = $this->owner_type( $series_id );
+		// 一覧でも使うので、未知の値が1件でも混じって全体が落ちないようにする。
+		return $this->owner_types[ $type ] ?? $this->owner_types['writer'];
 	}
 
 	/**

--- a/themes/hametuha/src/Hametuha/Model/Series.php
+++ b/themes/hametuha/src/Hametuha/Model/Series.php
@@ -297,17 +297,17 @@ class Series extends Model {
 	}
 
 	/**
-	 * 単巻書籍の目次を取得する
+	 * 単巻書籍の内容紹介を取得する
 	 *
-	 * 本文が破滅派にないため収録作一覧を組み立てられない。書き手が自由記述した
-	 * HTML をそのまま保持する。
+	 * 本文が破滅派にないため収録作一覧を組み立てられない。目次・装丁・初出など、
+	 * 書き手が自由記述した HTML をそのまま保持する。
 	 *
 	 * @param int $post_id
 	 *
 	 * @return string
 	 */
-	public function get_toc( $post_id ) {
-		return trim( (string) get_post_meta( $post_id, '_book_toc', true ) );
+	public function get_book_description( $post_id ) {
+		return trim( (string) get_post_meta( $post_id, '_book_description', true ) );
 	}
 
 	/**

--- a/themes/hametuha/src/Hametuha/Model/Series.php
+++ b/themes/hametuha/src/Hametuha/Model/Series.php
@@ -282,6 +282,35 @@ class Series extends Model {
 	}
 
 	/**
+	 * 子投稿を持たない単巻書籍か
+	 *
+	 * 破滅派の外で制作した書籍をあとから電子化した場合、本文を入稿しないため
+	 * 子投稿が存在しない。「まだ作品が登録されていない空の連載」と区別する必要が
+	 * あるので、子の件数ではなく明示的なフラグで判定する。
+	 *
+	 * @param int $post_id
+	 *
+	 * @return bool
+	 */
+	public function is_standalone( $post_id ) {
+		return (bool) get_post_meta( $post_id, '_standalone_book', true );
+	}
+
+	/**
+	 * 単巻書籍の目次を取得する
+	 *
+	 * 本文が破滅派にないため収録作一覧を組み立てられない。書き手が自由記述した
+	 * HTML をそのまま保持する。
+	 *
+	 * @param int $post_id
+	 *
+	 * @return string
+	 */
+	public function get_toc( $post_id ) {
+		return trim( (string) get_post_meta( $post_id, '_book_toc', true ) );
+	}
+
+	/**
 	 * Get visibility of series
 	 *
 	 * @param int $series_id

--- a/themes/hametuha/tests/Test_Series.php
+++ b/themes/hametuha/tests/Test_Series.php
@@ -234,6 +234,32 @@ class Test_Series extends WP_UnitTestCase {
 	}
 
 	/**
+	 * 責任者の肩書きをテスト
+	 *
+	 * 一覧のカードでも使うため、不正な値で全体が落ちないことを担保する。
+	 */
+	public function test_owner_label() {
+		$collaborators = \Hametuha\Model\Collaborators::get_instance();
+		$series_id     = $this->factory->post->create( [
+			'post_type'   => 'series',
+			'post_status' => 'draft',
+		] );
+
+		// 未設定なら「著」。
+		$this->assertSame( '著', $collaborators->owner_label( $series_id ) );
+
+		update_post_meta( $series_id, '_owner_type', 'editor' );
+		$this->assertSame( '編集', $collaborators->owner_label( $series_id ) );
+
+		update_post_meta( $series_id, '_owner_type', 'self_produce' );
+		$this->assertSame( '編著', $collaborators->owner_label( $series_id ) );
+
+		// 未知の値でも例外にせず既定値へ倒す。
+		update_post_meta( $series_id, '_owner_type', 'unknown_type' );
+		$this->assertSame( '著', $collaborators->owner_label( $series_id ) );
+	}
+
+	/**
 	 * 一覧から「子投稿のない連載」だけが除外されることをテスト
 	 *
 	 * hooks/series.php の posts_join フィルターの回帰テスト。SQL を直接書いているため

--- a/themes/hametuha/tests/Test_Series.php
+++ b/themes/hametuha/tests/Test_Series.php
@@ -231,11 +231,6 @@ class Test_Series extends WP_UnitTestCase {
 		$this->assertTrue( hametuha_is_standalone_book( $child_id ) );
 		// 親を持たない投稿は常に false。
 		$this->assertFalse( hametuha_is_standalone_book( $orphan_id ) );
-
-		// 目次は series からのみ取れる。
-		update_post_meta( $series_id, '_book_toc', '<ul><li>第一章</li></ul>' );
-		$this->assertSame( '<ul><li>第一章</li></ul>', hametuha_get_book_toc( $series_id ) );
-		$this->assertSame( '', hametuha_get_book_toc( $child_id ) );
 	}
 
 	/**

--- a/themes/hametuha/tests/Test_Series.php
+++ b/themes/hametuha/tests/Test_Series.php
@@ -165,6 +165,147 @@ class Test_Series extends WP_UnitTestCase {
 	}
 
 	/**
+	 * 単巻書籍フラグをテスト
+	 */
+	public function test_is_standalone() {
+		// publish に遷移させると計測フック（cookie-tasting プラグイン依存）が走るため draft で作る。
+		$series_id = $this->factory->post->create( [
+			'post_type'   => 'series',
+			'post_status' => 'draft',
+		] );
+
+		// 未設定なら連載扱い。子が0件でも単巻書籍とはみなさない。
+		$this->assertFalse( $this->series->is_standalone( $series_id ) );
+
+		update_post_meta( $series_id, '_standalone_book', 1 );
+		$this->assertTrue( $this->series->is_standalone( $series_id ) );
+
+		// 明示的に0を入れた場合も連載扱い。
+		update_post_meta( $series_id, '_standalone_book', 0 );
+		$this->assertFalse( $this->series->is_standalone( $series_id ) );
+	}
+
+	/**
+	 * 目次の取得をテスト
+	 */
+	public function test_get_toc() {
+		$series_id = $this->factory->post->create( [
+			'post_type'   => 'series',
+			'post_status' => 'draft',
+		] );
+
+		// 未設定なら空文字列。
+		$this->assertSame( '', $this->series->get_toc( $series_id ) );
+
+		// 空白のみでも空文字列として扱う（セクションを出さない判定に使うため）。
+		update_post_meta( $series_id, '_book_toc', "  \n " );
+		$this->assertSame( '', $this->series->get_toc( $series_id ) );
+
+		$toc = '<ol><li>吾輩は猫である</li></ol>';
+		update_post_meta( $series_id, '_book_toc', $toc );
+		$this->assertSame( $toc, $this->series->get_toc( $series_id ) );
+	}
+
+	/**
+	 * テンプレートタグが series と子投稿の両方で解決することをテスト
+	 */
+	public function test_standalone_template_tag() {
+		$series_id = $this->factory->post->create( [
+			'post_type'   => 'series',
+			'post_status' => 'draft',
+		] );
+		$child_id  = $this->factory->post->create( [
+			'post_type'   => 'post',
+			'post_status' => 'draft',
+			'post_parent' => $series_id,
+		] );
+		$orphan_id = $this->factory->post->create( [
+			'post_type'   => 'post',
+			'post_status' => 'draft',
+		] );
+
+		update_post_meta( $series_id, '_standalone_book', 1 );
+
+		$this->assertTrue( hametuha_is_standalone_book( $series_id ) );
+		// 子投稿からは親を辿る。
+		$this->assertTrue( hametuha_is_standalone_book( $child_id ) );
+		// 親を持たない投稿は常に false。
+		$this->assertFalse( hametuha_is_standalone_book( $orphan_id ) );
+
+		// 目次は series からのみ取れる。
+		update_post_meta( $series_id, '_book_toc', '<ul><li>第一章</li></ul>' );
+		$this->assertSame( '<ul><li>第一章</li></ul>', hametuha_get_book_toc( $series_id ) );
+		$this->assertSame( '', hametuha_get_book_toc( $child_id ) );
+	}
+
+	/**
+	 * 一覧から「子投稿のない連載」だけが除外されることをテスト
+	 *
+	 * hooks/series.php の posts_join フィルターの回帰テスト。SQL を直接書いているため
+	 * 壊れても表示を見るまで気づきにくい。
+	 */
+	public function test_archive_excludes_empty_series_but_keeps_standalone() {
+		$with_child = $this->create_published_series( '子のある連載' );
+		$this->create_published_post( '子作品', $with_child );
+
+		$empty = $this->create_published_series( '空の連載' );
+
+		$standalone = $this->create_published_series( '単巻書籍' );
+		update_post_meta( $standalone, '_standalone_book', 1 );
+
+		$this->go_to( home_url( '/?post_type=series' ) );
+		$found = wp_list_pluck( $GLOBALS['wp_query']->posts, 'ID' );
+
+		$this->assertContains( $with_child, $found, '子投稿のある連載は一覧に出る' );
+		$this->assertContains( $standalone, $found, '単巻書籍は子がなくても一覧に出る' );
+		$this->assertNotContains( $empty, $found, '空の連載は従来どおり一覧に出ない' );
+	}
+
+	/**
+	 * 公開済みの series を作る
+	 *
+	 * publish に遷移させると計測フック（cookie-tasting プラグイン依存）が走るため、
+	 * draft で作ってから DB を直接書き換える。
+	 *
+	 * @param string $title タイトル。
+	 * @return int
+	 */
+	protected function create_published_series( $title ) {
+		return $this->create_published( $title, 'series', 0 );
+	}
+
+	/**
+	 * 公開済みの投稿を作る
+	 *
+	 * @param string $title  タイトル。
+	 * @param int    $parent 親のseries ID。
+	 * @return int
+	 */
+	protected function create_published_post( $title, $parent ) {
+		return $this->create_published( $title, 'post', $parent );
+	}
+
+	/**
+	 * @param string $title     タイトル。
+	 * @param string $post_type 投稿タイプ。
+	 * @param int    $parent    親ID。
+	 * @return int
+	 */
+	protected function create_published( $title, $post_type, $parent ) {
+		global $wpdb;
+		$post_id = $this->factory->post->create( [
+			'post_type'   => $post_type,
+			'post_status' => 'draft',
+			'post_title'  => $title,
+			'post_parent' => $parent,
+		] );
+		$wpdb->update( $wpdb->posts, [ 'post_status' => 'publish' ], [ 'ID' => $post_id ] );
+		clean_post_cache( $post_id );
+
+		return $post_id;
+	}
+
+	/**
 	 * 空文字列やnullのテスト
 	 */
 	public function test_empty_values() {

--- a/themes/hametuha/tests/Test_Series.php
+++ b/themes/hametuha/tests/Test_Series.php
@@ -186,24 +186,24 @@ class Test_Series extends WP_UnitTestCase {
 	}
 
 	/**
-	 * 目次の取得をテスト
+	 * 内容紹介の取得をテスト
 	 */
-	public function test_get_toc() {
+	public function test_get_book_description() {
 		$series_id = $this->factory->post->create( [
 			'post_type'   => 'series',
 			'post_status' => 'draft',
 		] );
 
 		// 未設定なら空文字列。
-		$this->assertSame( '', $this->series->get_toc( $series_id ) );
+		$this->assertSame( '', $this->series->get_book_description( $series_id ) );
 
 		// 空白のみでも空文字列として扱う（セクションを出さない判定に使うため）。
-		update_post_meta( $series_id, '_book_toc', "  \n " );
-		$this->assertSame( '', $this->series->get_toc( $series_id ) );
+		update_post_meta( $series_id, '_book_description', "  \n " );
+		$this->assertSame( '', $this->series->get_book_description( $series_id ) );
 
-		$toc = '<ol><li>吾輩は猫である</li></ol>';
-		update_post_meta( $series_id, '_book_toc', $toc );
-		$this->assertSame( $toc, $this->series->get_toc( $series_id ) );
+		$description = '<ol><li>吾輩は猫である</li></ol>';
+		update_post_meta( $series_id, '_book_description', $description );
+		$this->assertSame( $description, $this->series->get_book_description( $series_id ) );
 	}
 
 	/**


### PR DESCRIPTION
## 概要

破滅派の外で制作した書籍をあとから電子化するフローに対応します。

`series` は「作品集であるとともに連載」という前提で作られており、本文は子投稿として入稿されます。しかし外部で作った書籍を入稿し直すのは非現実的なため、これまでは**非公開の連載**として登録するしかありませんでした。売上報告はそれで回りますが、`/kdp`（破滅派の電子書籍）に出せません。導線としては最上位に置きたいので、これを解消します。

`_standalone_book` フラグを立てた series を「単巻書籍」として扱い、算出できない情報を出さず、収録作一覧のかわりに自由記述の**内容紹介**を表示します。

## 「子が0件」を判定条件にしなかった理由

現在すでに子なしで公開されている series が11件あります（6413 青い鳥の詩集 / 6830 小説集 / 8744 百貨店奇談１ ほか）。**すべて ASIN なし・`_kdp_status` なしの「空のまま放置された連載」**で、これらにとって

> まだ作品が登録されていません。破滅派をフォローして、作者の活躍に期待してください。

は正しいメッセージです。子の件数で判定すると、この11件が電子書籍の顔をし始めます。そのため明示フラグで区別しています。

## 一覧クエリの修正（レビューで見てほしい点）

`hooks/series.php` に、子投稿ゼロの series を弾く `posts_join` フィルターがありました。

```php
// 少なくとも1つは公開済みの子投稿が紐づいている連載のみを表示
$join .= " INNER JOIN ( SELECT DISTINCT post_parent FROM {$wpdb->posts} ... )";
```

これは `is_main_query()` のときだけ効くため、症状が分裂していました。

| 露出先 | クエリ種別 | 修正前 |
|---|---|---|
| `/kdp`・`/series` | メインクエリ | **除外されて出ない** |
| おすすめ書籍・フッター電子書籍一覧 | `new WP_Query` | 普通に出る |

サブクエリを `UNION` にして単巻書籍を通しました。**空連載11件は従来どおり除外されたまま**です。

SQL 直書きは壊れても表示を見るまで気づかないため、`Test_Series::test_archive_excludes_empty_series_but_keeps_standalone()` で回帰テストを書き、**修正を戻すと落ちること（ミューテーション）まで確認**しています。

## 表示の変更

単巻書籍のときだけ分岐します。通常の連載の表示は一切変わりません。

| 箇所 | 修正前（子が0件） | 修正後 |
|---|---|---|
| ステータス | `完結済み（　〜　）` 括弧だけ残る | `刊行済み` |
| | `0 作品収録` | 出さない |
| | `0文字（400字詰原稿用紙0枚）` | 出さない |
| 収録作一覧 | 「まだ作品が登録されていません…」 | **内容紹介**（空なら節ごと非表示） |
| アンカーボタン | 収録作一覧 | 内容紹介（内容紹介が空なら出さない） |
| 一覧カード | `0作（文字数不明）` `連載中` | 刊行日と「刊行済み」バッジのみ |
| `<title>` | `（破滅派, 2026年-, 完結）` | `（破滅派, 2026年, 刊行済み）` |

`single-series.php` が507行あったため、収録作一覧と内容紹介をそれぞれ `parts/series-children.php` / `parts/series-description.php` に切り出し、両形態を対称に扱えるようにしました。

## 修正不要だったもの（調査済み）

- **売上按分・売上報告**: `Collaborators::get_final_margin()` は `relationships` を `object_id = series_id` で引き、端数を `$series->post_author` に寄せるだけ。`Sales::default_join()` は ASIN → postmeta → series で結合。**子投稿を参照する箇所はゼロ**なので、子なしでもそのまま動きます
- **執筆者一覧**: `get_published_collaborators()` が series の `post_author` を必ず含むため空になりません
- **レビュー・購入導線・価格**: コメントと `_asin` 由来で子と無関係

## 一緒に直したもの

### 一覧カードの肩書き

カードが「編」を決め打ちしていたため、単著でも「高橋文樹 編」と出ていました。単体ページは `Collaborators::owner_label()` で「著」と出しており、**同じ作品で表記が食い違っていました**。カードも同じ値を使うようにしています（著／編集／編著／監修）。

あわせて `owner_label()` が未知の `_owner_type` で `Undefined array key` を起こさないよう既定値に倒しました。呼び出しが単体ページ1件から一覧84件に広がるため、1件でも不正値があるとアーカイブ全体が落ちるからです（現状のDBは9件すべて正当な値でした）。

### 内容紹介の改行

`wp_kses_post()` は改行を段落にしないため、平文で書くと全行が1行に潰れていました。「自由記述」と説明しながらHTMLを書ける人しか使えない状態だったので `wpautop` を通しています。将来この行に変換が挟まっても守られるよう、サニタイザを最後に置きました。

なお保存側は素通し（`Input::post()` の生値が `update_post_meta()` へ）なので、**この meta の安全性は出力側が kses を通すことに依存**しています。現状の描画箇所は1か所、`_` 始まりで REST にも出ないため実害はありませんが、別の場所で出すときは注意が必要です。

## 検証

`composer test` 71件 OK（`Test_Series` に4件追加）、新規行は phpcs clean。

実データで Playwright 確認済み。比較対象として既存の販売中書籍（9737「ここにいるよ」子26件）を複製し、子を持たない検証用データを作って**差分が書籍形態だけになる**ようにしました（ASIN はダミー値にして売上集計を汚さないようにしています）。

| 対象 | 結果 |
|---|---|
| 単巻書籍 | 上表のとおり。虚偽表示がすべて消滅 |
| 通常の連載（9737） | 完結済み（2015年7月24日〜8月9日）／26作品収録／205,685文字／収録作一覧 — **完全に無変化** |
| 空連載（6413） | 「まだ作品が登録されていません」が**従来どおり** |
| `/kdp` | 32冊 → 33冊 |
| `/series` | 83作 → 84作（増えたのは単巻書籍のみ） |
| 管理画面 | 実ログインでメタボックス描画・**保存（403なし・DB反映）**・形態の切り戻しまで確認 |
| kses | `<script>` のタグ除去・`onclick` 属性除去・`<ol>` が `<p>` に包まれないことを確認 |

## 今回やらないこと

- **ePub 生成**: 単巻書籍は本文を持たないため `hampost compile` / ePub 出力の対象外です。`Series::validate()` は「作品が1つも登録されていません」で必ず失敗しますが、この導線に乗らないため触っていません
- **共著者の作者ページへの露出**: `parts/list-kdp.php` は series の `post_author` で引くため collaborator の作者ページには出ません。既存の連載でも同じ挙動なので範囲外としました

## 使い方

1. series を作成し、表紙・リード文・ASIN・価格を入力
2. 「書籍の形態」メタボックスで **単巻書籍** を選択
3. 「内容紹介」に目次・装丁・初出などを記入（HTML可・省略可）
4. 公開すると `/kdp`・`/series`・おすすめ書籍・作者ページの著作一覧に出ます

🤖 Generated with [Claude Code](https://claude.com/claude-code)
